### PR TITLE
graphics_eng rework

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# spaces in graphics.lua
+74a05105f61e5d8d7d2770c223dc16d3847244cf

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,6 @@
 # spaces in graphics.lua
 74a05105f61e5d8d7d2770c223dc16d3847244cf
+# loader 4 spaces
+8590bd41e21ae8640551311cc24a379078c7f386
+# main.lua: 4 spaces
+14673e73c8805fd3d59d6b2909e16ba63d491abe

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ out
 vsbuild
 .vscode
 .DS_Store
+questbuild

--- a/lua/eng/assets_eng.lua
+++ b/lua/eng/assets_eng.lua
@@ -131,7 +131,7 @@ end
 function AssetsEng:loadImage(asset_id, callback, flipped)
     assert(string.match(asset_id, "asset:"), "not an asset id")
 
-    self:getAsset(asset_id, function(asset)
+    return self:getAsset(asset_id, function(asset)
         if asset then
             self:loadFromAsset(asset, "texture-asset", callback, flipped)
         else
@@ -143,13 +143,30 @@ end
 function AssetsEng:loadTexture(asset_id, callback)
     assert(string.match(asset_id, "asset:"), "not an asset id")
 
-    self:loadImage(asset_id, function(image)
+    return self:loadImage(asset_id, function(image)
         if image then
             callback(lovr.graphics.newTexture(image))
         else
             print("Failed to load texture data")
+            callback(nil)
         end
     end)
+end
+
+function AssetsEng:loadModel(asset_id, callback)
+    assert(string.match(asset_id, "asset:"), "not an asset id")
+
+    self:getAsset(asset_id, function (asset)
+        if asset then
+            self:loadFromAsset(asset, "model-asset", function (modelData)
+                callback(modelData and lovr.graphics.newModel(modelData))
+            end)
+        else
+            print("failed to load model data")
+            callback(nil)
+        end
+    end)
+    return nil
 end
 
 

--- a/lua/eng/assets_eng.lua
+++ b/lua/eng/assets_eng.lua
@@ -132,6 +132,17 @@ function AssetsEng:onUpdate(dt)
     end
 end
 
+function AssetsEng:loadSoundEffect(asset_id, callback)
+    assert(string.match(asset_id, "asset:"), "not an asset id")
+
+    return self:getOrLoadResource(asset_id, callback, function (asset, complete)
+        if not asset then complete(nil) end
+        self.parent.engines.assets:loadFromAsset(asset, "sound-asset", function (soundData)
+            complete(soundData and lovr.audio.newSource(soundData))
+        end)        
+    end)
+end
+
 function AssetsEng:loadImage(asset_id, callback, flipped)
     assert(string.match(asset_id, "asset:"), "not an asset id")
 

--- a/lua/eng/assets_eng.lua
+++ b/lua/eng/assets_eng.lua
@@ -194,11 +194,9 @@ function AssetsEng:getOrLoadResource(type, asset_id, callback, map)
     -- If there's a cached object for asset_id then return it immediately
     local object = self.cache[key]
     if object then 
-        print("hit for " .. asset_id)
         callback(object)
         return object
     end
-    print("miss for " .. asset_id)
     
     -- If the asset is already loading then wait for it
     local callbacks = self.loaders[key]
@@ -219,7 +217,6 @@ function AssetsEng:getOrLoadResource(type, asset_id, callback, map)
             local callbacks = self.loaders[key]
             self.loaders[key] = nil
             -- call the callbaks
-            print(#callbacks .. " multicall for " .. asset_id)
             for i,callback in ipairs(callbacks) do
                 callback(object)
             end

--- a/lua/eng/assets_eng.lua
+++ b/lua/eng/assets_eng.lua
@@ -13,7 +13,7 @@ function AssetsEng:_init()
     self.droppedPaths = nil
     self.droppedModels = {}
 
-    self.loaders = {} --assetid:{callback}
+    self.loaders = {} -- "type-assetid":{callback}
     self.cache = setmetatable({}, {__mode = 'v'})--assetid:lovrTypes
 end
 
@@ -40,12 +40,12 @@ end
 
 --- Loads asset data asynchronously. 
 -- Supported types:
--- * "model-asset"
--- * "texture-asset" - Produces an Image
--- * "sound-asset"
+-- * "model"
+-- * "texture" - Produces an Image
+-- * "sound"
 -- returns true if asynchronous loading started, or false if 
 -- object was already loaded and callback called immediately
--- @tparam bool flipTexture If type is 'texture-asset' this specifies that the Image should be returned flipped
+-- @tparam bool flipTexture If type is 'texture' this specifies that the Image should be returned flipped
 function AssetsEng:loadFromAsset(asset, type, callback, flipTexture)
     if asset._lovrObjectLoadingCallbacks then
       table.insert(asset._lovrObjectLoadingCallbacks, callback)
@@ -135,20 +135,20 @@ end
 function AssetsEng:loadSoundEffect(asset_id, callback)
     assert(string.match(asset_id, "asset:"), "not an asset id")
 
-    return self:getOrLoadResource(asset_id, callback, function (asset, complete)
-        if not asset then complete(nil) end
-        self.parent.engines.assets:loadFromAsset(asset, "sound-asset", function (soundData)
+    return self:getOrLoadResource("sound", asset_id, callback, function (asset, complete)
+        if not asset then return complete(nil) end
+        self:loadFromAsset(asset, "sound", function (soundData)
             complete(soundData and lovr.audio.newSource(soundData))
-        end)        
+        end)
     end)
 end
 
 function AssetsEng:loadImage(asset_id, callback, flipped)
     assert(string.match(asset_id, "asset:"), "not an asset id")
 
-    return self:getOrLoadResource(asset_id, callback, function(asset, complete)
+    return self:getOrLoadResource("image", asset_id, callback, function(asset, complete)
         if not asset then return complete(nil) end
-        self:loadFromAsset(asset, "texture-asset", function (image)
+        self:loadFromAsset(asset, "image", function (image)
             complete(image)
         end, flipped)
     end)
@@ -157,9 +157,10 @@ end
 function AssetsEng:loadTexture(asset_id, callback)
     assert(string.match(asset_id, "asset:"), "not an asset id")
 
-    return self:getOrLoadResource(asset_id, callback, function (asset, complete)
-        self:loadFromAsset(asset, "texture-asset", function (image)
-            complete(lovr.graphics.newTexture(image))
+    return self:getOrLoadResource("texture", asset_id, callback, function (asset, complete)
+        if not asset then return complete(nil) end
+        self:loadFromAsset(asset, "texture", function (image)
+            complete(image and lovr.graphics.newTexture(image))
         end)
     end)
 end
@@ -167,9 +168,9 @@ end
 function AssetsEng:loadModel(asset_id, callback)
     assert(string.match(asset_id, "asset:"), "not an asset id")
 
-    return self:getOrLoadResource(asset_id, callback, function (asset, complete)
+    return self:getOrLoadResource("model", asset_id, callback, function (asset, complete)
         if not asset then return complete(nil) end
-        self:loadFromAsset(asset, "model-asset", function (modelData)
+        self:loadFromAsset(asset, "model", function (modelData)
             complete(modelData and lovr.graphics.newModel(modelData))
         end)
     end)
@@ -187,32 +188,36 @@ function AssetsEng:loadCustomMesh(geometry_asset, callback)
     return self:loadModel(asset:id(), callback)
 end
 
+
+function AssetsEng:getOrLoadResource(type, asset_id, callback, map)
+    local key = type .. '-' .. asset_id
     -- If there's a cached object for asset_id then return it immediately
-    local object = self.cache[asset_id]
+    local object = self.cache[key]
     if object then 
         print("hit for " .. asset_id)
         callback(object)
         return object
     end
+    print("miss for " .. asset_id)
     
     -- If the asset is already loading then wait for it
-    local callbacks = self.loaders[asset_id]
+    local callbacks = self.loaders[key]
     if callbacks then 
         table.insert(callbacks, callback)
         return nil
     end
 
     -- Start loading
-    self.loaders[asset_id] = {callback}
-    -- Load the addet
+    self.loaders[key] = {callback}
+    -- Load the asset
     self:getAsset(asset_id, function (asset)
         -- map to object
-        worker(asset, function (object)
+        map(asset, function (object)
             -- store in cache
-            self.cache[asset_id] = object
+            self.cache[key] = object
             -- clear the callbacks
-            local callbacks = self.loaders[asset_id]
-            self.loaders[asset_id] = nil
+            local callbacks = self.loaders[key]
+            self.loaders[key] = nil
             -- call the callbaks
             print(#callbacks .. " multicall for " .. asset_id)
             for i,callback in ipairs(callbacks) do
@@ -220,6 +225,7 @@ end
             end
         end)
     end)
+    return nil
 end
 
 return AssetsEng

--- a/lua/eng/assets_eng.lua
+++ b/lua/eng/assets_eng.lua
@@ -14,8 +14,7 @@ function AssetsEng:_init()
     self.droppedModels = {}
 
     self.loaders = {} --assetid:{callback}
-    self.cache = {}--assetid:lovrTypes
-    self.cache.__mode = 'v' -- weak values
+    self.cache = setmetatable({}, {__mode = 'v'})--assetid:lovrTypes
 end
 
 function AssetsEng:onLoad()

--- a/lua/eng/assets_eng.lua
+++ b/lua/eng/assets_eng.lua
@@ -176,12 +176,12 @@ function AssetsEng:loadModel(asset_id, callback)
     end)
 end
 
-function AssetsEng:loadCustomMesh(geometry_asset, callback)
-    -- already added? 
+function AssetsEng:loadCustomModel(geometry_asset, callback)
+    -- Add to manager if needed
     local asset = self.assetManager:get(geometry_asset:id())
     if not asset then 
         asset = geometry_asset
-        self.assetManager:add(asset, true)
+        self.assetManager:add(asset)
     end
 
     -- load it

--- a/lua/eng/assets_eng.lua
+++ b/lua/eng/assets_eng.lua
@@ -175,7 +175,18 @@ function AssetsEng:loadModel(asset_id, callback)
     end)
 end
 
-function AssetsEng:getOrLoadResource(asset_id, callback, worker)
+function AssetsEng:loadCustomMesh(geometry_asset, callback)
+    -- already added? 
+    local asset = self.assetManager:get(geometry_asset:id())
+    if not asset then 
+        asset = geometry_asset
+        self.assetManager:add(asset, true)
+    end
+
+    -- load it
+    return self:loadModel(asset:id(), callback)
+end
+
     -- If there's a cached object for asset_id then return it immediately
     local object = self.cache[asset_id]
     if object then 

--- a/lua/eng/assets_eng.lua
+++ b/lua/eng/assets_eng.lua
@@ -43,10 +43,6 @@ end
 -- object was already loaded and callback called immediately
 -- @tparam bool flipTexture If type is 'texture-asset' this specifies that the Image should be returned flipped
 function AssetsEng:loadFromAsset(asset, type, callback, flipTexture)
-    if asset._lovrObject then 
-      callback(asset._lovrObject)
-      return
-    end
     if asset._lovrObjectLoadingCallbacks then
       table.insert(asset._lovrObjectLoadingCallbacks, callback)
       return
@@ -63,10 +59,9 @@ function AssetsEng:loadFromAsset(asset, type, callback, flipTexture)
         if object == nil or status == false then
           print("Failed to load " .. type, asset:id(), object)
         else
-          asset._lovrObject = object
-        end
-        for _, cb in ipairs(asset._lovrObjectLoadingCallbacks) do
-          cb(asset._lovrObject)
+            for _, cb in ipairs(asset._lovrObjectLoadingCallbacks) do
+                cb(object)
+            end
         end
         asset._lovrObjectLoadingCallbacks = nil
       end,

--- a/lua/eng/graphics_eng.lua
+++ b/lua/eng/graphics_eng.lua
@@ -168,20 +168,16 @@ function GraphicsEng:loadHardcodedModel(name, callback, path)
         path = path .. ".glb"
     end
     callback(self.hardcoded_models.loading)
-    loader:load(
-        "model",
-        path,
-        function(modelData, status)
-            if modelData == nil or status == false then
-                print("Failed to load model", name, ":", model)
-                self.hardcoded_models[name] = self.hardcoded_models.broken
-            else
-                local model = graphics.newModel(modelData)
-                self.hardcoded_models[name] = model
-            end
-            callback(self.hardcoded_models[name])
+    local asset = Asset.File(path)
+    self.parent.engines.assets:loadCustomMesh(asset, function(modelData, status)
+        if model then 
+            self.hardcoded_models[name] = model
+        else
+            print("Failed to load model", name, ":", model)
+            self.hardcoded_models[name] = self.hardcoded_models.broken
         end
-    )
+        callback(self.hardcoded_models[name])
+    end)
 end
 
 function GraphicsEng:loadEnvironment(component, wasRemoved)
@@ -283,6 +279,7 @@ function GraphicsEng:buildObject(entity, component_key, old_component, removed)
             
             self.parent.engines.assets:loadModel(component.name, function(model)
                 if not object == self.renderObjects[entityId] then return end
+                if not (entity and entity.components and entity.components.transform) then return end
                 if model then
                     object.lovr.model = model
                     object.AABB = self:aabbForModel(object.lovr.model, entity.components.transform:getMatrix())

--- a/lua/eng/graphics_eng.lua
+++ b/lua/eng/graphics_eng.lua
@@ -54,7 +54,6 @@ function GraphicsEng:onLoad()
 
   self.models_for_eids = {}
   self.materials_for_eids = {}
-  self.textures_from_assets = {}
   
   self.basicShader = alloBasicShader
   self.pbrShader = alloPbrShader

--- a/lua/eng/graphics_eng.lua
+++ b/lua/eng/graphics_eng.lua
@@ -3,14 +3,10 @@
 
 namespace("networkscene", "alloverse")
 
-local array2d = require "pl.array2d"
 local tablex = require "pl.tablex"
 local pretty = require "pl.pretty"
-local allomath = require("lib.allomath")
 local alloBasicShader = require "shader/alloBasicShader"
 local alloPbrShader = require "shader/alloPbrShader"
-local loader = require "lib.async-loader"
-local util = require("lib.util")
 local Asset = require("lib.alloui.lua.alloui.asset")
 local Store = require("lib.lovr-store")
 
@@ -21,7 +17,6 @@ local Renderer = require('eng.renderer')
 local graphics = lovr.graphics
 local vec3 = lovr.math.vec3
 local newVec3 = lovr.math.newVec3
-local newMat4 = lovr.math.newMat4
 
 --- Initialize the graphics engine.
 function GraphicsEng:_init()

--- a/lua/eng/graphics_eng.lua
+++ b/lua/eng/graphics_eng.lua
@@ -169,7 +169,7 @@ function GraphicsEng:loadHardcodedModel(name, callback, path)
     end
     callback(self.hardcoded_models.loading)
     local asset = Asset.File(path)
-    self.parent.engines.assets:loadCustomMesh(asset, function(modelData, status)
+    self.parent.engines.assets:loadCustomModel(asset, function(modelData, status)
         if model then 
             self.hardcoded_models[name] = model
         else
@@ -274,7 +274,7 @@ function GraphicsEng:buildObject(entity, component_key, old_component, removed)
             local asset = Asset.Geometry(component)
             object.lovr.model = self.hardcoded_models.loading
             object.AABB = self:aabbForModel(object.lovr.model, entity.components.transform:getMatrix())
-            self.parent.engines.assets:loadCustomMesh(asset, function (model)
+            self.parent.engines.assets:loadCustomModel(asset, function (model)
                 if not object == self.renderObjects[entityId] then return end
                 if not (entity and entity.components and entity.components.transform) then return end
                 if model then

--- a/lua/eng/graphics_eng.lua
+++ b/lua/eng/graphics_eng.lua
@@ -258,8 +258,6 @@ function GraphicsEng:handleVideo(entity, component, old_component)
     if (component or old_component).type ~= "video" then return end
     local track_id = (component or old_component).track_id
     local media = self.videoMedia[track_id]
-    pretty.dump(component or old_component)
-    pretty.dump(media)
     if not component and old_component and media then -- removed
         print("Removing video track " .. track_id)
         self.videoMedia[track_id] = nil
@@ -400,7 +398,6 @@ function GraphicsEng:buildObject(entity, component_key, old_component, removed)
                     self.videoMedia[track_id] = media
                 end
             end
-            pretty.dump(component)
         end
     end
 

--- a/lua/eng/graphics_eng.lua
+++ b/lua/eng/graphics_eng.lua
@@ -25,73 +25,73 @@ local newMat4 = lovr.math.newMat4
 
 --- Initialize the graphics engine.
 function GraphicsEng:_init()
-  self:super()
-
-  -- Paint every entity in a differnet shade? Nice to figure out what be longs what
-  self.colorfulDebug = false
-  -- Draw model boinding boxes?
-  self.drawAABBs = false
-  -- Draw spheres at the center of AABB's?
-  self.drawAABBCenters = false
-
-  -- A list of models loaded from a directory for previewing
-  self.testModels = {}
-
-  self.defaultAmbientLightColor = {0.4,0.4,0.4,1}
-
-  self.renderer = Renderer()
-  self.renderObjects = {}
-  self.aabb_for_model = {}
+    self:super()
+    
+    -- Paint every entity in a differnet shade? Nice to figure out what be longs what
+    self.colorfulDebug = false
+    -- Draw model boinding boxes?
+    self.drawAABBs = false
+    -- Draw spheres at the center of AABB's?
+    self.drawAABBCenters = false
+    
+    -- A list of models loaded from a directory for previewing
+    self.testModels = {}
+    
+    self.defaultAmbientLightColor = {0.4,0.4,0.4,1}
+    
+    self.renderer = Renderer()
+    self.renderObjects = {}
+    self.aabb_for_model = {}
 end
 
 --- Called when the application loads.
 -- Loads the default models, shaders, etc. 
 function GraphicsEng:onLoad()
-  self.hardcoded_models = {
-    broken = graphics.newModel('/assets/models/broken.glb'),
-    loading = graphics.newModel('/assets/models/loading.glb'),
-  }
-
-  self.models_for_eids = {}
-  self.materials_for_eids = {}
-  
-  self.basicShader = alloBasicShader
-  self.pbrShader = alloPbrShader
-
-  graphics.setBackgroundColor(.05, .05, .05)
-  
-  local skyboxName = "sunset"
-  self.cloudSkybox = graphics.newTexture({
-    left =  'assets/textures/skybox/' .. skyboxName .. '/left.png',
-    right = 'assets/textures/skybox/' .. skyboxName .. '/right.png',
-    top =   'assets/textures/skybox/' .. skyboxName .. '/top.png',
-    bottom = 'assets/textures/skybox/' .. skyboxName .. '/bottom.png',
-    back = 'assets/textures/skybox/' .. skyboxName .. '/back.png',
-    front = 'assets/textures/skybox/' .. skyboxName .. '/front.png'
-  }, {
-    type = "cube",
-    mipmaps = true
-  })
-  self.renderer.defaultEnvironmentMap = self.cloudSkybox
-  self.renderer.ambientLightColor = self.defaultAmbientLightColor
-  self.renderer.drawSkybox = true
-  -- self.renderer.debug = "distance"
-
-  local videoMedia = {}
-  self.videoMedia = videoMedia
-  self.client.delegates.onVideo = function(track, pixels, width, height)
-    local media = videoMedia[track]
-    if not media then return end -- noone wants this
-    media.texture:replacePixels(pixels)
-  end
-
-  self.testModels = {}
-  local houseAssetNames = lovr.filesystem.getDirectoryItems("assets/models/testing")
-  for i, name in ipairs(houseAssetNames) do
-    self:loadHardcodedModel('testing/'..name, function(m) 
-      table.insert(self.testModels, m)
-    end)
-  end
+    self.hardcoded_models = {
+        broken = graphics.newModel('/assets/models/broken.glb'),
+        loading = graphics.newModel('/assets/models/loading.glb'),
+    }
+    
+    self.models_for_eids = {}
+    self.materials_for_eids = {}
+    
+    self.basicShader = alloBasicShader
+    self.pbrShader = alloPbrShader
+    
+    graphics.setBackgroundColor(.05, .05, .05)
+    
+    local skyboxName = "sunset"
+    self.cloudSkybox = graphics.newTexture({
+        left =  'assets/textures/skybox/' .. skyboxName .. '/left.png',
+        right = 'assets/textures/skybox/' .. skyboxName .. '/right.png',
+        top =   'assets/textures/skybox/' .. skyboxName .. '/top.png',
+        bottom = 'assets/textures/skybox/' .. skyboxName .. '/bottom.png',
+        back = 'assets/textures/skybox/' .. skyboxName .. '/back.png',
+        front = 'assets/textures/skybox/' .. skyboxName .. '/front.png'
+    }, {
+        type = "cube",
+        mipmaps = true
+    })
+    self.renderer.defaultEnvironmentMap = self.cloudSkybox
+    self.renderer.ambientLightColor = self.defaultAmbientLightColor
+    self.renderer.drawSkybox = true
+    -- self.renderer.debug = "distance"
+    
+    local videoMedia = {}
+    self.videoMedia = videoMedia
+    self.client.delegates.onVideo = function(track, pixels, width, height)
+        local media = videoMedia[track]
+        if not media then return end -- noone wants this
+        media.texture:replacePixels(pixels)
+    end
+    
+    self.testModels = {}
+    local houseAssetNames = lovr.filesystem.getDirectoryItems("assets/models/testing")
+    for i, name in ipairs(houseAssetNames) do
+        self:loadHardcodedModel('testing/'..name, function(m) 
+            table.insert(self.testModels, m)
+        end)
+    end
 end
 
 function GraphicsEng:aabbForModel(model, transform)
@@ -118,7 +118,7 @@ function GraphicsEng:onDraw()
     graphics.clear(false, true, true)
     graphics.setCullingEnabled(true)
     graphics.setColor(1, 1, 1, 1)
-
+    
     local aabbForModel = self.aabbForModel
     
     -- Collect all the objects to sort and draw
@@ -136,7 +136,7 @@ function GraphicsEng:onDraw()
                 metalness = 0,
                 roughness = 1
             }
-
+            
             -- Transparent obects have opposite draw order than opaque objects
             local material_alpha = material and material.color and type(material.color[4]) == "number" and material.color[4] or 1
             local hasTransparency = material and material.hasTransparency or material_alpha < 1
@@ -156,7 +156,7 @@ function GraphicsEng:onDraw()
                 },
                 draw = function(object, context)
                     -- TODO: not nice with an inline closure but will be less expensive with a managed object list
-
+                    
                     -- Hide head from view but not from reflections.
                     -- TODO: This is stupid expensive for what it does. Move to somewhere
                     if context.view.nr == 1 then
@@ -165,7 +165,7 @@ function GraphicsEng:onDraw()
                             return
                         end
                     end
-
+                    
                     -- Is this reeeeally the right place to handle animations at all?
                     -- TODO: some hack so this it only run for entities that needs it
                     local animationCount = model.animate and model:getAnimationCount()
@@ -173,12 +173,12 @@ function GraphicsEng:onDraw()
                         local name = model:getAnimationName(1)
                         for i = 1, animationCount do 
                             if model:getAnimationName(i) == "autoplay" then
-                            name = "autoplay"
+                                name = "autoplay"
                             end
                         end
                         model:animate(name, lovr.timer.getTime())
                     end
-
+                    
                     if material.color then
                         lovr.graphics.setColor(table.unpack(material.color))
                         model:draw(transform)
@@ -190,7 +190,7 @@ function GraphicsEng:onDraw()
             }
         end
     end
-
+    
     --- Add objects that are drag&dropped into the visor
     for i, model in ipairs(self.testModels) do
         table.insert(objects, {
@@ -202,12 +202,12 @@ function GraphicsEng:onDraw()
             end
         })
     end
-  
+    
     -- clear eventual old objects
     for j = count + 1, #objects do
         objects[j] = nil
     end
-  
+    
     -- Draw all of them (unless things are not initialized properly)
     if self.parent:getHead() then 
         local headPosition = self.parent:getHead().components.transform:getMatrix():mul(vec3())
@@ -223,40 +223,40 @@ end
 -- @tparam component component The component to load the model for
 -- @tparam component old_component The previous component state, if any
 function GraphicsEng:loadComponentModel(component, old_component)
-  local eid = component.getEntity().id
-
-  if component.type == "hardcoded-model" then
-    self:loadHardcodedModel(component.name, function(model)
-      self.models_for_eids[eid] = model
-    end)
-  elseif component.type == "inline" then 
-    local model = self:createMesh(component, old_component)
-    self.models_for_eids[eid] = model
-    local material = self.materials_for_eids[eid]
-    if material and model.setMaterial then
-      model:setMaterial(material)
-    end
-  elseif component.type == "asset" then
-    local cached = self.parent.engines.assets:getAsset(component.name, function (asset)
-      if asset then 
-        local model = self:modelFromAsset(asset, function (model)
-          self.models_for_eids[eid] = model
+    local eid = component.getEntity().id
+    
+    if component.type == "hardcoded-model" then
+        self:loadHardcodedModel(component.name, function(model)
+            self.models_for_eids[eid] = model
         end)
-      else
-        self.models_for_eids[eid] = self.hardcoded_models.broken
-      end
-    end)
-    if cached == nil then 
-      self.models_for_eids[eid] = self.hardcoded_models.loading
+    elseif component.type == "inline" then 
+        local model = self:createMesh(component, old_component)
+        self.models_for_eids[eid] = model
+        local material = self.materials_for_eids[eid]
+        if material and model.setMaterial then
+            model:setMaterial(material)
+        end
+    elseif component.type == "asset" then
+        local cached = self.parent.engines.assets:getAsset(component.name, function (asset)
+            if asset then 
+                local model = self:modelFromAsset(asset, function (model)
+                    self.models_for_eids[eid] = model
+                end)
+            else
+                self.models_for_eids[eid] = self.hardcoded_models.broken
+            end
+        end)
+        if cached == nil then 
+            self.models_for_eids[eid] = self.hardcoded_models.loading
+        end
     end
-  end
-
-  -- after loading, apply material if already loaded
-  local mat = self.materials_for_eids[eid]
-  local model = self.models_for_eids[eid]
-  if mat and model and model.setMaterial then
-    model:setMaterial(mat)
-  end
+    
+    -- after loading, apply material if already loaded
+    local mat = self.materials_for_eids[eid]
+    local model = self.models_for_eids[eid]
+    if mat and model and model.setMaterial then
+        model:setMaterial(mat)
+    end
 end
 
 --- Load a bundled model by name.
@@ -265,153 +265,153 @@ end
 -- @param callback A funcion that takes one argument: the loaded model. Called when the model is fuly loaded.
 -- @tparam string path Optional. The file to load. If not supplied then a path into the "assets/models" folder will be build from `name`
 function GraphicsEng:loadHardcodedModel(name, callback, path)
-  local model = self.hardcoded_models[name]
-  if model then
-    callback(model)
-    return
-  end
-  path = path and path or '/assets/models/'..name
-  if not path:has_suffix(".glb") and not path:has_suffix(".gltf") then
-    path = path .. ".glb"
-  end
-  callback(self.hardcoded_models.loading)
-  loader:load(
+    local model = self.hardcoded_models[name]
+    if model then
+        callback(model)
+        return
+    end
+    path = path and path or '/assets/models/'..name
+    if not path:has_suffix(".glb") and not path:has_suffix(".gltf") then
+        path = path .. ".glb"
+    end
+    callback(self.hardcoded_models.loading)
+    loader:load(
     "model",
     path,
     function(modelData, status)
-       if modelData == nil or status == false then
-         print("Failed to load model", name, ":", model)
-         self.hardcoded_models[name] = self.hardcoded_models.broken
-       else
-         local model = graphics.newModel(modelData)
-         self.hardcoded_models[name] = model
-       end
-       callback(self.hardcoded_models[name])
+        if modelData == nil or status == false then
+            print("Failed to load model", name, ":", model)
+            self.hardcoded_models[name] = self.hardcoded_models.broken
+        else
+            local model = graphics.newModel(modelData)
+            self.hardcoded_models[name] = model
+        end
+        callback(self.hardcoded_models[name])
     end
-  )
+)
 end
 
 function GraphicsEng:loadTexture(eid, base64, callback)
-  loader:load(
+    loader:load(
     "base64png",
     "base64png/"..eid,
     function(texdata, status)
-       if texdata== nil or status == false then
-         print("Failed to load base64 texture", eid, ":", texdata)
-       else
-         local tex = graphics.newTexture(texdata)
-         callback(tex)
-       end
+        if texdata== nil or status == false then
+            print("Failed to load base64 texture", eid, ":", texdata)
+        else
+            local tex = graphics.newTexture(texdata)
+            callback(tex)
+        end
     end,
     base64
-  )
+)
 end
 
 --- Loads a material for supplied component.
 -- @tparam component component The component to load a material for
 -- @tparam component old_component not used
 function GraphicsEng:loadComponentMaterial(component, old_component)
-  local ent = component.getEntity()
-  local eid = ent.id
-
-  if ent.components.live_media then
-    print("not overriding video material with static material for", eid)
-    return
-  end
-
-
-  local mat = graphics.newMaterial()
-  if component.color ~= nil then
-    mat:setColor("diffuse", component.color[1], component.color[2], component.color[3], component.color[4])
-  end
-
-  local apply = function(texture)
-    mat:setTexture(texture)
-    self.materials_for_eids[eid] = mat
-    -- apply the material to matching mesh, if loaded
-    local model = self.models_for_eids[eid]
-    if model and model.setMaterial then
-      model:setMaterial(mat)
+    local ent = component.getEntity()
+    local eid = ent.id
+    
+    if ent.components.live_media then
+        print("not overriding video material with static material for", eid)
+        return
     end
-    component.diffuseTexture = texture
-  end
-  
-  local textureName = component.texture or component.asset_texture
-  if textureName == nil then
-    apply()
-  else
-    if string.match(textureName, "asset:") then
-      self.parent.engines.assets:getAsset(textureName, function(asset)
-        if asset then 
-          self:textureFromAsset(asset, apply)
-        else
-          print("Texture asset " .. textureName .. " was not found")
-        end  
-      end)
+    
+    
+    local mat = graphics.newMaterial()
+    if component.color ~= nil then
+        mat:setColor("diffuse", component.color[1], component.color[2], component.color[3], component.color[4])
+    end
+    
+    local apply = function(texture)
+        mat:setTexture(texture)
+        self.materials_for_eids[eid] = mat
+        -- apply the material to matching mesh, if loaded
+        local model = self.models_for_eids[eid]
+        if model and model.setMaterial then
+            model:setMaterial(mat)
+        end
+        component.diffuseTexture = texture
+    end
+    
+    local textureName = component.texture or component.asset_texture
+    if textureName == nil then
+        apply()
     else
-      -- backwards compat.
-      self:loadTexture(eid, textureName, apply)
+        if string.match(textureName, "asset:") then
+            self.parent.engines.assets:getAsset(textureName, function(asset)
+                if asset then 
+                    self:textureFromAsset(asset, apply)
+                else
+                    print("Texture asset " .. textureName .. " was not found")
+                end  
+            end)
+        else
+            -- backwards compat.
+            self:loadTexture(eid, textureName, apply)
+        end
     end
-  end
 end
 
 function GraphicsEng:loadEnvironment(component, wasRemoved)
-  if wasRemoved then component = nil end
-  -- TODO: Merge all active environment components. 
-  -- TODO: Build a table with all environments and their bounds and switch env as player moves between them
-  if component and component.ambient and component.ambient.light and component.ambient.light.color then
-    self.renderer.ambientLightColor = component.ambient.light.color or {0,0,0,1}
-  elseif self.defaultAmbientLightColor then
-    self.renderer.ambientLightColor = self.defaultAmbientLightColor
-  end
-  if component and component.skybox then
-    self:loadCubemap(component.skybox, function(cubeTexture)
-      self.renderer.defaultEnvironmentMap = cubeTexture
-    end)
-  elseif self.cloudSkybox then 
-    self.renderer.defaultEnvironmentMap = self.cloudSkybox
-  end
+    if wasRemoved then component = nil end
+    -- TODO: Merge all active environment components. 
+    -- TODO: Build a table with all environments and their bounds and switch env as player moves between them
+    if component and component.ambient and component.ambient.light and component.ambient.light.color then
+        self.renderer.ambientLightColor = component.ambient.light.color or {0,0,0,1}
+    elseif self.defaultAmbientLightColor then
+        self.renderer.ambientLightColor = self.defaultAmbientLightColor
+    end
+    if component and component.skybox then
+        self:loadCubemap(component.skybox, function(cubeTexture)
+            self.renderer.defaultEnvironmentMap = cubeTexture
+        end)
+    elseif self.cloudSkybox then 
+        self.renderer.defaultEnvironmentMap = self.cloudSkybox
+    end
 end
 
 --- Called when a new component is added
 -- @tparam string component_key The component type
 -- @tparam component component The new component
 function GraphicsEng:onComponentAdded(component_key, component)
-  local eid = component.getEntity().id
-  if component_key == "geometry" then
-    self:loadComponentModel(component, nil)
-  elseif component_key == "material" then
-    self:loadComponentMaterial(component, nil)
-  elseif component_key == "environment" then
-    self:loadEnvironment(component)
-  elseif component_key == "live_media" then
-    if component.type == "video" then
-      local media = self.videoMedia[component.track_id]
-      print("media component was added for", eid)
-      pretty.dump(component)
-      if not media then
-        media = {
-          texture = lovr.graphics.newTexture(component.metadata.width, component.metadata.height, 1, {
-            mipmaps = false,
-            format = "rgba"
-          }),
-          material = lovr.graphics.newMaterial()
-        }
-        media.texture:setWrap('clamp', 'clamp')
-        media.texture:setFilter('nearest', 0)
-        media.material:setTexture(media.texture)
-        self.videoMedia[component.track_id] = media
-        local model = self.models_for_eids[eid]
-        self.materials_for_eids[eid] = media.material
-        media.eid = eid
-        if model and model.setMaterial then
-          model:setMaterial(media.material)
+    local eid = component.getEntity().id
+    if component_key == "geometry" then
+        self:loadComponentModel(component, nil)
+    elseif component_key == "material" then
+        self:loadComponentMaterial(component, nil)
+    elseif component_key == "environment" then
+        self:loadEnvironment(component)
+    elseif component_key == "live_media" then
+        if component.type == "video" then
+            local media = self.videoMedia[component.track_id]
+            print("media component was added for", eid)
+            pretty.dump(component)
+            if not media then
+                media = {
+                    texture = lovr.graphics.newTexture(component.metadata.width, component.metadata.height, 1, {
+                        mipmaps = false,
+                        format = "rgba"
+                    }),
+                    material = lovr.graphics.newMaterial()
+                }
+                media.texture:setWrap('clamp', 'clamp')
+                media.texture:setFilter('nearest', 0)
+                media.material:setTexture(media.texture)
+                self.videoMedia[component.track_id] = media
+                local model = self.models_for_eids[eid]
+                self.materials_for_eids[eid] = media.material
+                media.eid = eid
+                if model and model.setMaterial then
+                    model:setMaterial(media.material)
+                end
+                print(model)
+                pretty.dump(media)
+            end
         end
-        print(model)
-        pretty.dump(media)
-      end
     end
-  end
 end
 
 --- Called when a component has changed
@@ -419,38 +419,38 @@ end
 -- @tparam component component The new component state
 -- @tparam component old_component The previous component state
 function GraphicsEng:onComponentChanged(component_key, component, old_component)
-  local eid = component.getEntity().id
-  if component_key == "geometry" then
-    self:loadComponentModel(component, old_component)
-  elseif component_key == "material" then
-    self:loadComponentMaterial(component, old_component)
-  elseif component_key == "environment" then
-    self:loadEnvironment(component)
-  elseif component_key == "live_media" then
-    if component.type == "video" then
-      local media = self.videoMedia[component.track_id]
-      if not media then
-        media = {
-          material = lovr.graphics.newMaterial()
-        }
-        self.videoMedia[component.track_id] = media
-        local model = self.models_for_eids[eid]
-        self.materials_for_eids[eid] = media.material
-        media.eid = eid
-        if model and model.setMaterial then
-          model:setMaterial(media.material)
+    local eid = component.getEntity().id
+    if component_key == "geometry" then
+        self:loadComponentModel(component, old_component)
+    elseif component_key == "material" then
+        self:loadComponentMaterial(component, old_component)
+    elseif component_key == "environment" then
+        self:loadEnvironment(component)
+    elseif component_key == "live_media" then
+        if component.type == "video" then
+            local media = self.videoMedia[component.track_id]
+            if not media then
+                media = {
+                    material = lovr.graphics.newMaterial()
+                }
+                self.videoMedia[component.track_id] = media
+                local model = self.models_for_eids[eid]
+                self.materials_for_eids[eid] = media.material
+                media.eid = eid
+                if model and model.setMaterial then
+                    model:setMaterial(media.material)
+                end
+            end
+            media.texture = lovr.graphics.newTexture(component.metadata.width, component.metadata.height, 1, {
+                mipmaps = false,
+                format = "rgba"
+            })
+            media.material:setTexture(media.texture)
+            print("Video media was altered for", eid)
+            pretty.dump(component)
+            pretty.dump(media)
         end
-      end
-      media.texture = lovr.graphics.newTexture(component.metadata.width, component.metadata.height, 1, {
-        mipmaps = false,
-        format = "rgba"
-      })
-      media.material:setTexture(media.texture)
-      print("Video media was altered for", eid)
-      pretty.dump(component)
-      pretty.dump(media)
     end
-  end
 end
 
 
@@ -458,25 +458,25 @@ end
 -- @tparam string component_key The component type
 -- @tparam component component The removed component
 function GraphicsEng:onComponentRemoved(component_key, component)
-  local eid = component.getEntity().id
-  if component_key == "geometry" then
-    self.models_for_eids[eid] = nil
-  elseif component_key == "material" then
-    self.materials_for_eids[eid] = nil
-  elseif component_key == "environment" then
-    self:loadEnvironment(component, true)
-  elseif component_key == "live_media" then
-    if component.type == "video" then
-      local media = self.videoMedia[component.track_id]
-      self.materials_for_eids[eid] = nil
-      self.videoMedia[component.track_id] = nil
-      print("Removing video media for", eid)
-      local model = self.models_for_eids[eid]
-      if model and model.setMaterial then
-        model:setMaterial(nil)
-      end
+    local eid = component.getEntity().id
+    if component_key == "geometry" then
+        self.models_for_eids[eid] = nil
+    elseif component_key == "material" then
+        self.materials_for_eids[eid] = nil
+    elseif component_key == "environment" then
+        self:loadEnvironment(component, true)
+    elseif component_key == "live_media" then
+        if component.type == "video" then
+            local media = self.videoMedia[component.track_id]
+            self.materials_for_eids[eid] = nil
+            self.videoMedia[component.track_id] = nil
+            print("Removing video media for", eid)
+            local model = self.models_for_eids[eid]
+            if model and model.setMaterial then
+                model:setMaterial(nil)
+            end
+        end
     end
-  end
 end
 
 --- Creates a mesh for a geometry component
@@ -488,22 +488,22 @@ function GraphicsEng:createMesh(geom, old_geom)
     if old_geom then
         --print("createMesh", tablex.deepcompare(geom.triangles, old_geom.triangles), tablex.deepcompare(geom.vertices, old_geom.vertices), tablex.deepcompare(geom.uvs, old_geom.uvs))
     end
-
+    
     if mesh == nil
-        or not tablex.deepcompare(geom.triangles, old_geom.triangles)
-        or not tablex.deepcompare(geom.vertices, old_geom.vertices)
-        or not tablex.deepcompare(geom.uvs, old_geom.uvs)
-        or not tablex.deepcompare(geom.normals, old_geom.normals) then
-
+    or not tablex.deepcompare(geom.triangles, old_geom.triangles)
+    or not tablex.deepcompare(geom.vertices, old_geom.vertices)
+    or not tablex.deepcompare(geom.uvs, old_geom.uvs)
+    or not tablex.deepcompare(geom.normals, old_geom.normals) then
+        
         if geom.normals == nil then 
             geom = self:generateGeometryWithNormals(geom)
         end
-
+        
         -- convert the flattened zero-based indices list
         local z_indices = array2d.flatten(geom.triangles)
         -- convert to 1-based
         local indices = tablex.map(function (x) return x + 1 end, z_indices)
-
+        
         -- figure out vertex format
         local vertex_data = {geom.vertices}
         local mesh_format = {{'lovrPosition', 'float', 3}}
@@ -517,56 +517,56 @@ function GraphicsEng:createMesh(geom, old_geom)
         end
         -- zip together vertex data
         local combined = tablex.zip(unpack(vertex_data))
-
+        
         -- flatten the inner tables
         local vertices = tablex.map(function (x) return array2d.flatten(x) end, combined)
-
+        
         -- Setup the mesh
         mesh = graphics.newMesh(
-            mesh_format,
-            vertices,
-            'triangles', -- DrawMode
-            'static', -- MeshUsage. dynamic, static, stream
-            false -- do we need to read the data from the mesh later
-        )
-
-        mesh:setVertices(vertices)
-        mesh:setVertexMap(indices)
-
-        -- build aabb
-        local minx, maxx, miny, maxy, minz, maxz
-        for i, pt in ipairs(geom.vertices) do
-            local x, y, z = table.unpack(pt)
-            if not minx or x < minx then minx = x end
-            if not miny or y < miny then miny = y end
-            if not minz or z < minz then minz = z end
-
-            if not maxx or x > maxx then maxx = x end
-            if not maxy or y > maxy then maxy = y end
-            if not maxz or z > maxz then maxz = z end
-        end
+        mesh_format,
+        vertices,
+        'triangles', -- DrawMode
+        'static', -- MeshUsage. dynamic, static, stream
+        false -- do we need to read the data from the mesh later
+    )
+    
+    mesh:setVertices(vertices)
+    mesh:setVertexMap(indices)
+    
+    -- build aabb
+    local minx, maxx, miny, maxy, minz, maxz
+    for i, pt in ipairs(geom.vertices) do
+        local x, y, z = table.unpack(pt)
+        if not minx or x < minx then minx = x end
+        if not miny or y < miny then miny = y end
+        if not minz or z < minz then minz = z end
         
-        local aabb = {
-            min = newVec3(minx, miny, minz),
-            max = newVec3(maxx, maxy, maxz)
-        }
-        self.aabb_for_model[mesh] = aabb
+        if not maxx or x > maxx then maxx = x end
+        if not maxy or y > maxy then maxy = y end
+        if not maxz or z > maxz then maxz = z end
     end
+    
+    local aabb = {
+        min = newVec3(minx, miny, minz),
+        max = newVec3(maxx, maxy, maxz)
+    }
+    self.aabb_for_model[mesh] = aabb
+end
 
-    if (old_geom == nil or old_geom.texture ~= geom.texture) and geom.texture then
-        -- decode texture data and setup material
-        self:loadTexture(eid, geom.texture, function(tex)
+if (old_geom == nil or old_geom.texture ~= geom.texture) and geom.texture then
+    -- decode texture data and setup material
+    self:loadTexture(eid, geom.texture, function(tex)
         local material = graphics.newMaterial(tex)
         mesh:setMaterial(material)
-        end)
-    end
+    end)
+end
 
-    return mesh
+return mesh
 end
 
 --- Calculate vertex normal from three corner vertices
 local function get_triangle_normal(vert1, vert2, vert3)   
-  return vec3(vert3.x - vert1.x, vert3.z - vert1.z, vert3.y - vert1.y)
+    return vec3(vert3.x - vert1.x, vert3.z - vert1.z, vert3.y - vert1.y)
     :cross(vec3(vert2.x - vert1.x, vert2.z - vert1.z, vert2.y - vert1.y))
     :normalize()
 end
@@ -575,95 +575,95 @@ end
 -- @tparam geometry_component geom
 -- @treturn geometry_component new_geom
 function GraphicsEng:generateGeometryWithNormals(geom)
-  local new_geom = {
-    vertices = {}, triangles = {}, normals = {}, 
-    uvs = geom.uvs and {} or nil
-  }
-  for _, tri in ipairs(geom.triangles) do
-    local a, b, c = tri[1] + 1, tri[2] + 1, tri[3] + 1 -- vertex indices
-    local tri_vertices = {
-      vec3(table.unpack(geom.vertices[a])),
-      vec3(table.unpack(geom.vertices[b])),
-      vec3(table.unpack(geom.vertices[c]))
+    local new_geom = {
+        vertices = {}, triangles = {}, normals = {}, 
+        uvs = geom.uvs and {} or nil
     }
-    local normal = get_triangle_normal(unpack(tri_vertices))
-    for _, v in ipairs(tri_vertices) do
-      table.insert(new_geom.vertices, {v:unpack()})
-      table.insert(new_geom.normals, {normal:unpack()})
+    for _, tri in ipairs(geom.triangles) do
+        local a, b, c = tri[1] + 1, tri[2] + 1, tri[3] + 1 -- vertex indices
+        local tri_vertices = {
+            vec3(table.unpack(geom.vertices[a])),
+            vec3(table.unpack(geom.vertices[b])),
+            vec3(table.unpack(geom.vertices[c]))
+        }
+        local normal = get_triangle_normal(unpack(tri_vertices))
+        for _, v in ipairs(tri_vertices) do
+            table.insert(new_geom.vertices, {v:unpack()})
+            table.insert(new_geom.normals, {normal:unpack()})
+        end
+        table.insert(new_geom.triangles, {
+            #new_geom.vertices - 3, 
+            #new_geom.vertices - 2, 
+            #new_geom.vertices - 1
+        })
+        if (geom.uvs) then
+            table.insert(new_geom.uvs, geom.uvs[a])
+            table.insert(new_geom.uvs, geom.uvs[b])
+            table.insert(new_geom.uvs, geom.uvs[c])
+        end
     end
-    table.insert(new_geom.triangles, {
-      #new_geom.vertices - 3, 
-      #new_geom.vertices - 2, 
-      #new_geom.vertices - 1
-    })
-    if (geom.uvs) then
-      table.insert(new_geom.uvs, geom.uvs[a])
-      table.insert(new_geom.uvs, geom.uvs[b])
-      table.insert(new_geom.uvs, geom.uvs[c])
-    end
-  end
-  return new_geom
+    return new_geom
 end
 
 
 function GraphicsEng:modelFromAsset(asset, callback)
-  if self.parent.engines.assets:loadFromAsset(asset, "model-asset", function (modelData)
-    if modelData then 
-      callback(graphics.newModel(modelData))
-    else
-      print("Failed to parse model data for " .. asset:id())
-      callback(self.hardcoded_models.broken)
+    if self.parent.engines.assets:loadFromAsset(asset, "model-asset", function (modelData)
+        if modelData then 
+            callback(graphics.newModel(modelData))
+        else
+            print("Failed to parse model data for " .. asset:id())
+            callback(self.hardcoded_models.broken)
+        end
+    end) then
+        callback(self.hardcoded_models.loading)
     end
-  end) then
-    callback(self.hardcoded_models.loading)
-  end
 end
 
 function GraphicsEng:textureFromAsset(asset, callback)
-  self.parent.engines.assets:loadFromAsset(asset, "texture-asset", function (image)
-    if image then 
-      callback(graphics.newTexture(image))
-    else
-      print("Failed to load texture data")
-    end
-  end)
+    self.parent.engines.assets:loadFromAsset(asset, "texture-asset", function (image)
+        if image then 
+            callback(graphics.newTexture(image))
+        else
+            print("Failed to load texture data")
+        end
+    end)
 end
 
 function GraphicsEng:loadCubemap(asset_ids, callback)
-  local box = asset_ids
-  local failed = false
-  if box.left and box.right and box.top and box.bottom and box.front and box.back then
-    local sides = {}
-    local function request(side, asset_id)
-      local asset_id = box[side]
-      self.parent.engines.assets:loadImage(asset_id, function(image)
-        if failed then return end
-        if not image then
-          failed = true
-          print("Failed to load " .. side .. " part of a cubemap")
-          pretty.dump(asset_ids)
+    local box = asset_ids
+    local failed = false
+    if box.left and box.right and box.top and box.bottom and box.front and box.back then
+        local sides = {}
+        local function request(side, asset_id)
+            local asset_id = box[side]
+            self.parent.engines.assets:loadImage(asset_id, function(image)
+                if failed then return end
+                if not image then
+                    failed = true
+                    print("Failed to load " .. side .. " part of a cubemap")
+                    pretty.dump(asset_ids)
+                end
+                sides[side] = image
+                if sides.left and sides.right and sides.top and sides.bottom and sides.front and sides.back then
+                    callback(graphics.newTexture(sides))
+                end
+            end, true)
         end
-        sides[side] = image
-        if sides.left and sides.right and sides.top and sides.bottom and sides.front and sides.back then
-          callback(graphics.newTexture(sides))
-        end
-      end, true)
+        
+        request('left')
+        request('right')
+        request('bottom')
+        request('top')
+        request('front')
+        request('back')
+    else
+        print("Incomplete cubemap spec")
+        pretty.dump(asset_ids)
     end
-    
-    request('left')
-    request('right')
-    request('bottom')
-    request('top')
-    request('front')
-    request('back')
-  else
-    print("Incomplete cubemap spec")
-    pretty.dump(asset_ids)
-  end
 end
 
 function GraphicsEng:loadTextureAsset(asset_id, callback)
-  self.parent.engines.assets:loadTexture(asset_id, callback)
+    self.parent.engines.assets:loadTexture(asset_id, callback)
 end
 
 return GraphicsEng

--- a/lua/eng/graphics_eng.lua
+++ b/lua/eng/graphics_eng.lua
@@ -34,9 +34,6 @@ function GraphicsEng:_init()
     -- Draw spheres at the center of AABB's?
     self.drawAABBCenters = false
     
-    -- A list of models loaded from a directory for previewing
-    self.testModels = {}
-    
     self.defaultAmbientLightColor = {0.4,0.4,0.4,1}
     
     self.renderer = Renderer()
@@ -81,14 +78,6 @@ function GraphicsEng:onLoad()
         if not media then return end -- noone wants this
         media.texture:replacePixels(pixels)
     end
-    
-    self.testModels = {}
-    local houseAssetNames = lovr.filesystem.getDirectoryItems("assets/models/testing")
-    for i, name in ipairs(houseAssetNames) do
-        self:loadHardcodedModel('testing/'..name, function(m) 
-            table.insert(self.testModels, m)
-        end)
-    end
 end
 
 function GraphicsEng:aabbForModel(model, transform)
@@ -130,7 +119,7 @@ function GraphicsEng:onDraw()
     end
     
     --- Add objects that are drag&dropped into the visor
-    for i, model in ipairs(self.testModels) do
+    for i, model in ipairs(self.parent.engines.assets.droppedModels) do
         table.insert(objects, {
             id = "Test object " .. i,
             AABB = self:aabbForModel(model, lovr.math.mat4()),
@@ -317,14 +306,6 @@ function GraphicsEng:buildObject(entity, component_key, old_component, removed)
             roughness = component.roughness or 1,
             uvScale = component.uvScale or {1,1}
         }
-
-        -- todo: reuse or recreate material?
-        local material = object.lovr.material or lovr.graphics.newMaterial()
-        object.lovr.material = material
-        if component.color then 
-            local c = component.color
-            material:setColor("diffuse", c[1], c[2], c[3], c[4] or 1)
-        end
 
         if component.texture and component.texture:match("asset:") then
             self.parent.engines.assets:loadTexture(component.texture, function (texture)
@@ -516,9 +497,6 @@ function GraphicsEng:modelFromAsset(asset_id, callback)
     return self.parent.engines.assets:loadModel(asset_id, callback)
 end
 
-function GraphicsEng:textureFromAsset(asset_id, callback)
-    return self.parent.engines.assets:loadTexture(asset_id, callback)
-end
 
 function GraphicsEng:liveMediaAdded(component) 
     local eid = component:getEntity().id

--- a/lua/eng/graphics_eng.lua
+++ b/lua/eng/graphics_eng.lua
@@ -375,6 +375,7 @@ function GraphicsEng:buildObject(entity, component_key, old_component, removed)
                 uvScale = component.uvScale or {1,1}
             }
 
+            component.texture = component.asset_texture or component.texture -- back.compat
             if component.texture and component.texture:match("asset:") then
                 self.parent.engines.assets:loadTexture(component.texture, function (texture)
                     if not object == self.renderObjects[entityId] then return end

--- a/lua/eng/graphics_eng.lua
+++ b/lua/eng/graphics_eng.lua
@@ -439,51 +439,6 @@ function draw_object(object, renderObject, context)
     end
 end
 
---- Calculate vertex normal from three corner vertices
-local function get_triangle_normal(vert1, vert2, vert3)   
-    return vec3(vert3.x - vert1.x, vert3.z - vert1.z, vert3.y - vert1.y)
-    :cross(vec3(vert2.x - vert1.x, vert2.z - vert1.z, vert2.y - vert1.y))
-    :normalize()
-end
-
---- Create a new geom from the old one with unique triangle vertices and sharp normals
--- @tparam geometry_component geom
--- @treturn geometry_component new_geom
-function GraphicsEng:generateGeometryWithNormals(geom)
-    local new_geom = {
-        vertices = {}, triangles = {}, normals = {}, 
-        uvs = geom.uvs and {} or nil
-    }
-    for _, tri in ipairs(geom.triangles) do
-        local a, b, c = tri[1] + 1, tri[2] + 1, tri[3] + 1 -- vertex indices
-        local tri_vertices = {
-            vec3(table.unpack(geom.vertices[a])),
-            vec3(table.unpack(geom.vertices[b])),
-            vec3(table.unpack(geom.vertices[c]))
-        }
-        local normal = get_triangle_normal(unpack(tri_vertices))
-        for _, v in ipairs(tri_vertices) do
-            table.insert(new_geom.vertices, {v:unpack()})
-            table.insert(new_geom.normals, {normal:unpack()})
-        end
-        table.insert(new_geom.triangles, {
-            #new_geom.vertices - 3, 
-            #new_geom.vertices - 2, 
-            #new_geom.vertices - 1
-        })
-        if (geom.uvs) then
-            table.insert(new_geom.uvs, geom.uvs[a])
-            table.insert(new_geom.uvs, geom.uvs[b])
-            table.insert(new_geom.uvs, geom.uvs[c])
-        end
-    end
-    return new_geom
-end
-
-function GraphicsEng:modelFromAsset(asset_id, callback)
-    return self.parent.engines.assets:loadModel(asset_id, callback)
-end
-
 function GraphicsEng:loadCubemap(asset_ids, callback)
     local box = asset_ids
     local failed = false

--- a/lua/eng/graphics_eng.lua
+++ b/lua/eng/graphics_eng.lua
@@ -337,6 +337,7 @@ function GraphicsEng:buildObject(entity, component_key, old_component, removed)
         if component.texture and component.texture:match("asset:") then
             self.parent.engines.assets:loadTexture(component.texture, function (texture)
                 if not object == self.renderObjects[entityId] then return end
+                object.material.diffuseTexture = texture
                 if not texture then return end
                 object.lovr.material:setTexture(texture)
                 self:applyModelMaterial(object)

--- a/lua/eng/renderer.lua
+++ b/lua/eng/renderer.lua
@@ -320,7 +320,6 @@ function Renderer:prepareObjects(context)
                 renderObject.material.roughness = object.material.roughness or 1
                 renderObject.material.metalness = object.material.metalness or 1
                 renderObject.material.diffuseTexture = object.material.diffuseTexture
-                renderObject.material.liveTexture = object.live_media and object.live_media.texture
                 renderObject.material.uvScale = object.material.uvScale and {object.material.uvScale[1], object.material.uvScale[2], 1}
             else
                 renderObject.material = {
@@ -521,9 +520,9 @@ function Renderer:drawObject(object, context)
         send(shader, "alloMetalness", material.metalness or 1)
         send(shader, "alloRoughness", material.roughness or 1)
         send(shader, "alloUVScale", material.uvScale or {1, 1, 1})
-        if material.diffuseTexture or material.liveTexture then
+        if material.diffuseTexture then
             send(shader, "alloDiffuseTextureSet", 1)
-            send(shader, "alloDiffuseTexture", material.liveTexture or material.diffuseTexture)
+            send(shader, "alloDiffuseTexture", material.diffuseTexture)
         else
             send(shader, "alloDiffuseTexture", self._blankTexture)
             send(shader, "alloDiffuseTextureSet", 0)

--- a/lua/eng/renderer.lua
+++ b/lua/eng/renderer.lua
@@ -333,8 +333,8 @@ function Renderer:prepareObjects(context)
             local AABB = object.AABB
             local minmaxdiv2 = (AABB.max - AABB.min) / 2
             renderObject.AABB = {
-                min = lovr.math.newVec3(AABB.min),
-                max = lovr.math.newVec3(AABB.max),
+                min = AABB.min,
+                max = AABB.max,
                 center = lovr.math.newVec3(object.position + AABB.min + minmaxdiv2),
                 radius = minmaxdiv2:length(),
             }
@@ -562,6 +562,7 @@ function Renderer:drawObject(object, context)
         lovr.graphics.box("line", x, y, z, math.abs(w), math.abs(h), math.abs(d))
     end
 end
+
 
 -- this function is broken in lovr 0.14.0
 local function lookAt(eye, at, up)

--- a/lua/eng/renderer.lua
+++ b/lua/eng/renderer.lua
@@ -552,7 +552,7 @@ function Renderer:drawObject(object, context)
 
     context.stats.drawnObjectIds[object.id] = object.id
 
-    object.source.draw(object, context)
+    object.source:draw(object, context)
     
     if context.drawAABB then
         local bb = object.AABB

--- a/lua/eng/renderer.lua
+++ b/lua/eng/renderer.lua
@@ -320,6 +320,7 @@ function Renderer:prepareObjects(context)
                 renderObject.material.roughness = object.material.roughness or 1
                 renderObject.material.metalness = object.material.metalness or 1
                 renderObject.material.diffuseTexture = object.material.diffuseTexture
+                renderObject.material.liveTexture = object.live_media and object.live_media.texture
                 renderObject.material.uvScale = object.material.uvScale and {object.material.uvScale[1], object.material.uvScale[2], 1}
             else
                 renderObject.material = {
@@ -520,9 +521,9 @@ function Renderer:drawObject(object, context)
         send(shader, "alloMetalness", material.metalness or 1)
         send(shader, "alloRoughness", material.roughness or 1)
         send(shader, "alloUVScale", material.uvScale or {1, 1, 1})
-        if material.diffuseTexture then
+        if material.diffuseTexture or material.liveTexture then
             send(shader, "alloDiffuseTextureSet", 1)
-            send(shader, "alloDiffuseTexture", material.diffuseTexture)
+            send(shader, "alloDiffuseTexture", material.diffuseTexture or material.liveTexture)
         else
             send(shader, "alloDiffuseTexture", self._blankTexture)
             send(shader, "alloDiffuseTextureSet", 0)

--- a/lua/eng/renderer.lua
+++ b/lua/eng/renderer.lua
@@ -106,6 +106,7 @@ function Renderer:render(objects, options)
         maxReflectionDepth = 0, -- max reached depth (cubemap gen triggers a cubemap gen. This should not happen.)
         cubemapTargets = {}, -- object id's that got a cubemap generated this frame
         debugText = {}, -- just strings the renderer would like to output to the screen
+        inputObjectCount = #objects, -- number of objects put into the rene
     }
 
     context.cubemapFarPlane = context.cubemapFarPlane or 10

--- a/lua/eng/renderer.lua
+++ b/lua/eng/renderer.lua
@@ -523,7 +523,7 @@ function Renderer:drawObject(object, context)
         send(shader, "alloUVScale", material.uvScale or {1, 1, 1})
         if material.diffuseTexture or material.liveTexture then
             send(shader, "alloDiffuseTextureSet", 1)
-            send(shader, "alloDiffuseTexture", material.diffuseTexture or material.liveTexture)
+            send(shader, "alloDiffuseTexture", material.liveTexture or material.diffuseTexture)
         else
             send(shader, "alloDiffuseTexture", self._blankTexture)
             send(shader, "alloDiffuseTextureSet", 0)

--- a/lua/eng/sound_eng.lua
+++ b/lua/eng/sound_eng.lua
@@ -396,10 +396,8 @@ function SoundEng:onSoundEffectAdded(component)
   }
   self.effects[eid] = voice
 
-  self.parent.engines.assets:getAsset(component.asset, function (asset)
-    local model = self:sourceFromAsset(asset, function (source)
+  self.parent.engines.assets:loadSoundEffect(component.asset, function (source)
       voice.source = source
-    end)
   end)
 end
 
@@ -477,16 +475,6 @@ function SoundEng:onDisconnect()
     voice.source:stop()
   end
   self.effects = {}
-end
-
-function SoundEng:sourceFromAsset(asset, callback)
-  self.parent.engines.assets:loadFromAsset(asset, "sound-asset", function (soundData)
-    if soundData then 
-      callback(lovr.audio.newSource(soundData))
-    else
-      print("Failed to parse sound data for " .. asset:id())
-    end
-  end)
 end
 
 --- Subscribe or unsubscribe to a media track

--- a/lua/eng/stats_eng.lua
+++ b/lua/eng/stats_eng.lua
@@ -16,10 +16,31 @@ local margin = .05
 function StatsEng:_init()
     self:clear()
     self:super()
+    
+    self.graphSize = {60*5, 100}-- 5 seconds of data (if fps is capped at 60)
+    self.graphsImage = lovr.data.newImage(self.graphSize[1], self.graphSize[2], "rgba")
+    self.graphsTexture = lovr.graphics.newTexture(self.graphsImage, {
+        linear = true, mipmaps = false
+    })
+    self.graphsTexture:setFilter('nearest', 0)
+    self.graphMaterial = lovr.graphics.newMaterial(self.graphsTexture)
+    self.graphCursor = 0
+    self.graphNames = {}
 end
 
 function StatsEng:clear()
     self.stats = {}
+    
+end
+
+function StatsEng:graph(name, value, max, color)
+    color = color or {1, 0, 0, 1}
+    self.graphNames[#self.graphNames+1] = {
+        name = name, value = value, color = color, max = max
+    }
+    value = value/max
+    local y = math.min(math.max(0, (1-value) * self.graphSize[2]), self.graphSize[2]-1)
+    self.graphsImage:setPixel(self.graphCursor, y, unpack(color))
 end
 
 function StatsEng:set(key, value)
@@ -35,6 +56,11 @@ function StatsEng:statsString()
     for k, v in pairs(self.stats) do
         s = s .. k .. ":   " .. v .. "\n"
     end
+
+    self:graph("fps", lovr.timer.getFPS(), 60, {1,1,1,0.5})
+    self:graph("dt", lovr.timer.getDelta()*1000, 60, {1,0,0,0.5})
+    self:graph("dtavg", lovr.timer.getAverageDelta()*1000, 60, {1,0,0,1})
+    self:graph("ping", self.parent.client.client:get_latency()*1000, 60, {0.5,0.5,1,0.7})
 
     local renderStats = lovr.graphics.getStats()
 
@@ -82,12 +108,52 @@ function StatsEng:onMirror()
         lovr.graphics.setFont(flat.font)
         lovr.graphics.print(
             self:statsString(),
-            flat.aspect-margin, 1-margin, 0, 
-            flat.fontscale, 
-            0,0,1,0,0, 
+            flat.aspect-margin, 1-margin, 0,  -- x,y,z
+            flat.fontscale, --scale
+            0,0,1,0,--angle,ax,ay,az
+            0, --wrap,
             'right','top'
         )
+        self:drawGraph()
     end
+end
+
+function StatsEng:drawGraph()
+    -- draw the graph
+    self.graphsTexture:replacePixels(self.graphsImage)
+    local w = self.graphSize[1]/flat.pixwidth*6
+    local h = self.graphSize[2]/flat.pixheight*3
+    local t = (self.graphCursor+1)/self.graphSize[1]
+    lovr.graphics.plane(
+        self.graphMaterial, 
+        -flat.aspect+w/2+margin,1-h/2-margin,0, --xyz
+        w, h,--wh
+        0,0,0,0,--anglexyz
+        t,0,--uv
+        1,1--uvsize
+    )
+    self.graphCursor = self.graphCursor + 1
+    if self.graphCursor > self.graphSize[1]-1 then 
+        self.graphCursor = 0
+    end
+    -- draw graph legend
+    for i, s in ipairs(self.graphNames) do
+        lovr.graphics.setColor(unpack(s.color))
+        lovr.graphics.print(
+            s.name .. ":".. string.format("%.1f", s.value),--str,
+            -flat.aspect+margin+w+margin,1-margin - 0.04*(i-1),0,--xyz,
+            flat.fontscale,--scale
+            0,0,0,0,--anglezyz
+            0, --wrap
+            'left', 'top'
+        )
+    end
+    -- prepare next line
+    local c = {1/91, 1/194, 1, 0.5}
+    for y = 0,self.graphSize[2]-1 do
+        self.graphsImage:setPixel(self.graphCursor, y, unpack(c))
+    end
+    self.graphNames = {}
 end
 
 function StatsEng:onDraw2()
@@ -103,6 +169,5 @@ function StatsEng:onDraw2()
         -- 'right','top'
     )
 end
-
 
 return StatsEng

--- a/lua/eng/stats_eng.lua
+++ b/lua/eng/stats_eng.lua
@@ -5,6 +5,7 @@
 
 namespace "standard"
 local pretty = require "pl.pretty"
+local tablex = require "pl.tablex"
 
 local flat = require "engine.flat"
 
@@ -53,7 +54,9 @@ function StatsEng:statsString()
         self.lua_memory = collectgarbage("count")
     end
     
-    s = s .. "Graphics Objects: " .. #self.parent.engines.graphics.renderObjects .. "\n"
+    s = s .. "Graphics Objects: " .. #tablex.keys(self.parent.engines.graphics.renderObjects) .. "\n"
+    s = s .. "Cached assets: " .. #tablex.keys(self.parent.engines.assets.cache) .. "\n"
+
     s = "Lua KBytes: " .. self.lua_memory .. "\n" .. s
     if self.parent and self.parent.engines.graphics.renderStats then
         local renderStats = self.parent.engines.graphics.renderStats

--- a/lua/eng/stats_eng.lua
+++ b/lua/eng/stats_eng.lua
@@ -41,19 +41,20 @@ function StatsEng:statsString()
     for i,v in ipairs({"drawcalls", "renderpasses", "shaderswitches", "buffers", "textures", "buffermemory", "texturememory"}) do
         s = s .. v .. ":   " .. renderStats[v] .. "\n"
     end
-
+    
     if self.parent and self.parent.assetManager then 
         local stat = self.parent.assetManager:getStats()
         s = s .. "AssetManager: " .. stat["published"] .. ", " .. stat["loading"] .. ", " .. stat["cached"] .. ", " .. stat["disk"] .. "\n"
     end
-
+    
     self.second = (self.second or 1) + lovr.timer.getDelta()
     if self.second >= 1 then
         self.second = 0
         self.lua_memory = collectgarbage("count")
     end
-
-    s = "Lua KBytes: " .. self.lua_memory .. "\n" .. s            
+    
+    s = s .. "Graphics Objects: " .. #self.parent.engines.graphics.renderObjects .. "\n"
+    s = "Lua KBytes: " .. self.lua_memory .. "\n" .. s
     if self.parent and self.parent.engines.graphics.renderStats then
         local renderStats = self.parent.engines.graphics.renderStats
         local t = renderStats.cubemapTargets

--- a/lua/eng/text_eng.lua
+++ b/lua/eng/text_eng.lua
@@ -70,7 +70,7 @@ function TextEng:onDraw()
 end
 
 function TextEng:drawText(eid, entity, text)
-    local mat = self.parent.engines.graphics.materials_for_eids[eid]
+    local mat = self.parent.engines.graphics:meta(eid).material
     if mat then
         lovr.graphics.setColor(mat:getColor())
     else

--- a/lua/eng/text_eng.lua
+++ b/lua/eng/text_eng.lua
@@ -9,124 +9,124 @@ local letters = require("lib.letters.letters")
 
 local TextEng = classNamed("TextEng", Ent)
 function TextEng:_init()
-  self:super()
+    self:super()
 end
 
 function TextEng:onLoad()
-  self:setActive(true)
-  self.font = lovr.graphics.newFont(32)
+    self:setActive(true)
+    self.font = lovr.graphics.newFont(32)
 end
 
 function TextEng:onDie()
-  letters.hideKeyboard()
+    letters.hideKeyboard()
 end
 
 function TextEng:setActive(newActive)
-  if newActive then
-    local poseEng = self.parent.engines.pose
-    local headsetProxy = {}
-    local mt = {
-      -- inject self when used like `letters.headset.foobar(a, b, c)` (so it becomes basically
-      -- `textEng:foobar(a, b, c)`)
-      __index = function(t, key)
-        if poseEng[key] == nil then return nil end
-        return function(...)
-          return poseEng[key](poseEng, ...)
-        end
-      end
-    }
-    setmetatable(headsetProxy, mt)
-    letters.headset = headsetProxy
-    letters.load()
-  end
+    if newActive then
+        local poseEng = self.parent.engines.pose
+        local headsetProxy = {}
+        local mt = {
+            -- inject self when used like `letters.headset.foobar(a, b, c)` (so it becomes basically
+            -- `textEng:foobar(a, b, c)`)
+            __index = function(t, key)
+                if poseEng[key] == nil then return nil end
+                return function(...)
+                    return poseEng[key](poseEng, ...)
+                end
+            end
+        }
+        setmetatable(headsetProxy, mt)
+        letters.headset = headsetProxy
+        letters.load()
+    end
 end
 
 function TextEng:onUpdate()
-  if self.client == nil then return end
-
-  letters.update()
+    if self.client == nil then return end
+    
+    letters.update()
 end
 
 --- Draws all text components
 function TextEng:onDraw() 
-  lovr.graphics.setShader()
-  self.font:setPixelDensity(32)
-  lovr.graphics.setFont(self.font)
-  for eid, entity in pairs(self.client.state.entities) do
-    local text = entity.components.text
-    if text ~= nil then
-      self:drawText(eid, entity, text)
+    lovr.graphics.setShader()
+    self.font:setPixelDensity(32)
+    lovr.graphics.setFont(self.font)
+    for eid, entity in pairs(self.client.state.entities) do
+        local text = entity.components.text
+        if text ~= nil then
+            self:drawText(eid, entity, text)
+        end
     end
-  end
-
-  lovr.graphics.push()
-  lovr.graphics.transform(self.parent.inverseCameraTransform)
-  if not lovr.headset then
-    lovr.graphics.transform(self.parent.engines.pose:getPose("head"):invert())
-  end
-  letters.draw()
-
-  lovr.graphics.pop()
+    
+    lovr.graphics.push()
+    lovr.graphics.transform(self.parent.inverseCameraTransform)
+    if not lovr.headset then
+        lovr.graphics.transform(self.parent.engines.pose:getPose("head"):invert())
+    end
+    letters.draw()
+    
+    lovr.graphics.pop()
 end
 
 function TextEng:drawText(eid, entity, text)
-  local mat = self.parent.engines.graphics.materials_for_eids[eid]
-  if mat then
-    lovr.graphics.setColor(mat:getColor())
-  else
-    lovr.graphics.setColor(1,1,1,1)
-  end
-  lovr.graphics.push()
-  lovr.graphics.transform(entity.components.transform:getMatrix())
-
-  -- sets a dynamic text scale that fits within a width, if such parameter has been set
-  local dynamicTextScale = 0
-
-  if text.fitToWidth then
-
-    -- backwards compatibility
-    if type(text.fitToWidth) == "number" then
-      text.width = text.fitToWidth
-      text.fitToWidth = true
+    local mat = self.parent.engines.graphics.materials_for_eids[eid]
+    if mat then
+        lovr.graphics.setColor(mat:getColor())
+    else
+        lovr.graphics.setColor(1,1,1,1)
     end
-
-    local textLabelWidth = lovr.graphics.getFont():getWidth(text.string)
-    dynamicTextScale = text.width / textLabelWidth  
-  else
-    -- Fit text size to the element's height instead
-    dynamicTextScale = text.height and text.height or 1.0
-  end
-
-  -- old implementation:
-  -- local wrap = text.wrap and text.wrap / (text.height and text.height or 1) or 0
-
-  local wrap = 0
-  -- only care about setting wrap is fitToWidth hasn't been set
-  if not text.fitToWidth then
-    if text.wrap then
-      -- backwards compatibility
-      if type(text.wrap) == "number" then
-        text.width = text.wrap
-        text.wrap = true
-      end
-
-      wrap = text.width and text.width / (text.height and text.height or 1) or 0
+    lovr.graphics.push()
+    lovr.graphics.transform(entity.components.transform:getMatrix())
+    
+    -- sets a dynamic text scale that fits within a width, if such parameter has been set
+    local dynamicTextScale = 0
+    
+    if text.fitToWidth then
+        
+        -- backwards compatibility
+        if type(text.fitToWidth) == "number" then
+            text.width = text.fitToWidth
+            text.fitToWidth = true
+        end
+        
+        local textLabelWidth = lovr.graphics.getFont():getWidth(text.string)
+        dynamicTextScale = text.width / textLabelWidth  
+    else
+        -- Fit text size to the element's height instead
+        dynamicTextScale = text.height and text.height or 1.0
     end
-  end
-
-  if text.halign == "left" then
-    lovr.graphics.translate(-text.width/2,0,0)
-  elseif text.halign == "right" then
-    lovr.graphics.translate(text.width/2,0,0)
-  end
-
-  -- Make sure the text never overflows the height of the container (unless it's wrapped, which is fine.)
-  if dynamicTextScale > text.height then
-    dynamicTextScale = text.height
-  end
-
-
-  lovr.graphics.print(
+    
+    -- old implementation:
+    -- local wrap = text.wrap and text.wrap / (text.height and text.height or 1) or 0
+    
+    local wrap = 0
+    -- only care about setting wrap is fitToWidth hasn't been set
+    if not text.fitToWidth then
+        if text.wrap then
+            -- backwards compatibility
+            if type(text.wrap) == "number" then
+                text.width = text.wrap
+                text.wrap = true
+            end
+            
+            wrap = text.width and text.width / (text.height and text.height or 1) or 0
+        end
+    end
+    
+    if text.halign == "left" then
+        lovr.graphics.translate(-text.width/2,0,0)
+    elseif text.halign == "right" then
+        lovr.graphics.translate(text.width/2,0,0)
+    end
+    
+    -- Make sure the text never overflows the height of the container (unless it's wrapped, which is fine.)
+    if dynamicTextScale > text.height then
+        dynamicTextScale = text.height
+    end
+    
+    
+    lovr.graphics.print(
     text.string,
     0, 0, 0.01,
     dynamicTextScale, --text.height and text.height or 1.0, 
@@ -134,9 +134,9 @@ function TextEng:drawText(eid, entity, text)
     wrap,
     text.halign and text.halign or "center",
     text.valign and text.valign or "middle"
-  )
+)
 
-  if text.insertionMarker then
+if text.insertionMarker then
     lovr.graphics.setColor(0, 0, 0, math.sin(lovr.timer.getTime()*5)*0.5 + 0.6)
     local actualLabelWidth, lines = lovr.graphics.getFont():getWidth(text.string, wrap)
     actualLabelWidth = actualLabelWidth * dynamicTextScale
@@ -144,61 +144,61 @@ function TextEng:drawText(eid, entity, text)
     local lastLineWidth = lovr.graphics.getFont():getWidth(lastLine) * dynamicTextScale
     local height = self.font:getHeight()*dynamicTextScale
     lovr.graphics.line(
-      lastLineWidth + 0.01, height/2 - height*(lines-1), 0,
-      lastLineWidth + 0.01, height/2 - height*lines, 0
-    )
-  end
+    lastLineWidth + 0.01, height/2 - height*(lines-1), 0,
+    lastLineWidth + 0.01, height/2 - height*lines, 0
+)
+end
 
-  lovr.graphics.pop()
+lovr.graphics.pop()
 end
 
 function TextEng:onDebugDraw()
-  letters.debugDraw()
+    letters.debugDraw()
 end
 
 function TextEng:onFocusChanged(newEnt, focusType)
-  if focusType == "key" then
-    self.firstResponder = newEnt
-    if lovr.headset then
-      letters.displayKeyboard()
+    if focusType == "key" then
+        self.firstResponder = newEnt
+        if lovr.headset then
+            letters.displayKeyboard()
+        end
+    else
+        self.firstResponder = nil
+        letters.hideKeyboard()
     end
-  else
-    self.firstResponder = nil
-    letters.hideKeyboard()
-  end
-  self.parent.engines.pose:useKeyboardForControllerEmulation(self.firstResponder == nil)
+    self.parent.engines.pose:useKeyboardForControllerEmulation(self.firstResponder == nil)
 end
 
 function TextEng:onKeyPress(code, scancode, repetition)
-  if not self.firstResponder then return end
-
-  if code == "escape" then
-    return
-  end
-
-  self.client:sendInteraction({
-    type = "one-way",
-    receiver = self.firstResponder,
-    body = {"keydown", code, scancode, repetition}
-  })
+    if not self.firstResponder then return end
+    
+    if code == "escape" then
+        return
+    end
+    
+    self.client:sendInteraction({
+        type = "one-way",
+        receiver = self.firstResponder,
+        body = {"keydown", code, scancode, repetition}
+    })
 end
 function TextEng:onKeyReleased(code, scancode)
-  if not self.firstResponder then return end
-
-  self.client:sendInteraction({
-    type = "one-way",
-    receiver = self.firstResponder,
-    body = {"keyup", code, scancode}
-  })
+    if not self.firstResponder then return end
+    
+    self.client:sendInteraction({
+        type = "one-way",
+        receiver = self.firstResponder,
+        body = {"keyup", code, scancode}
+    })
 end
 function TextEng:onTextInput(text, code)
-  if not self.firstResponder then return end
-
-  self.client:sendInteraction({
-    type = "one-way",
-    receiver = self.firstResponder,
-    body = {"textinput", text, code}
-  })
+    if not self.firstResponder then return end
+    
+    self.client:sendInteraction({
+        type = "one-way",
+        receiver = self.firstResponder,
+        body = {"textinput", text, code}
+    })
 end
 
 return TextEng

--- a/lua/eng/text_eng.lua
+++ b/lua/eng/text_eng.lua
@@ -70,7 +70,8 @@ function TextEng:onDraw()
 end
 
 function TextEng:drawText(eid, entity, text)
-    local mat = self.parent.engines.graphics:meta(eid).material
+    local object = self.parent.engines.graphics.renderObjects[eid]
+    local mat = object and object.lovr.material
     if mat then
         lovr.graphics.setColor(mat:getColor())
     else
@@ -127,29 +128,29 @@ function TextEng:drawText(eid, entity, text)
     
     
     lovr.graphics.print(
-    text.string,
-    0, 0, 0.01,
-    dynamicTextScale, --text.height and text.height or 1.0, 
-    0, 0, 0, 0,
-    wrap,
-    text.halign and text.halign or "center",
-    text.valign and text.valign or "middle"
-)
+        text.string,
+        0, 0, 0.01,
+        dynamicTextScale, --text.height and text.height or 1.0, 
+        0, 0, 0, 0,
+        wrap,
+        text.halign and text.halign or "center",
+        text.valign and text.valign or "middle"
+    )
 
-if text.insertionMarker then
-    lovr.graphics.setColor(0, 0, 0, math.sin(lovr.timer.getTime()*5)*0.5 + 0.6)
-    local actualLabelWidth, lines = lovr.graphics.getFont():getWidth(text.string, wrap)
-    actualLabelWidth = actualLabelWidth * dynamicTextScale
-    local lastLine = string.match(text.string, "[^%c]*$")
-    local lastLineWidth = lovr.graphics.getFont():getWidth(lastLine) * dynamicTextScale
-    local height = self.font:getHeight()*dynamicTextScale
-    lovr.graphics.line(
-    lastLineWidth + 0.01, height/2 - height*(lines-1), 0,
-    lastLineWidth + 0.01, height/2 - height*lines, 0
-)
-end
+    if text.insertionMarker then
+        lovr.graphics.setColor(0, 0, 0, math.sin(lovr.timer.getTime()*5)*0.5 + 0.6)
+        local actualLabelWidth, lines = lovr.graphics.getFont():getWidth(text.string, wrap)
+        actualLabelWidth = actualLabelWidth * dynamicTextScale
+        local lastLine = string.match(text.string, "[^%c]*$")
+        local lastLineWidth = lovr.graphics.getFont():getWidth(lastLine) * dynamicTextScale
+        local height = self.font:getHeight()*dynamicTextScale
+        lovr.graphics.line(
+        lastLineWidth + 0.01, height/2 - height*(lines-1), 0,
+        lastLineWidth + 0.01, height/2 - height*lines, 0
+    )
+    end
 
-lovr.graphics.pop()
+    lovr.graphics.pop()
 end
 
 function TextEng:onDebugDraw()

--- a/lua/lib/async-loader-thread.lua
+++ b/lua/lib/async-loader-thread.lua
@@ -10,35 +10,35 @@ local outChan = lovr.thread.getChannel("AlloLoaderResponses")
 local inChan = lovr.thread.getChannel("AlloLoaderRequests")
 
 function load(type, path, extra, extra2)
-  if type == "model" then
-    -- expects a lovr blob in extra
-    return pcall(lovr.data.newModelData, extra)
-  elseif type == "texture" or type == "image" then
-    -- expects a lovr blob in extra
-    -- expects a boolean 'flip' in extra2
-    return pcall(lovr.data.newImage, extra, not extra2)
-  elseif type == "sound" then
-    -- expects a lovr blob in extra
-    return pcall(lovr.data.newSound, extra)
-  else
-    return false, "no such loader"
-  end
+    if type == "model" then
+        -- expects a lovr blob in extra
+        return pcall(lovr.data.newModelData, extra)
+    elseif type == "texture" or type == "image" then
+        -- expects a lovr blob in extra
+        -- expects a boolean 'flip' in extra2
+        return pcall(lovr.data.newImage, extra, not extra2)
+    elseif type == "sound" then
+        -- expects a lovr blob in extra
+        return pcall(lovr.data.newSound, extra)
+    else
+        return false, "no such loader"
+    end
 end
 
 local running = true
 while running do
-  local type = inChan:pop(true)
-  if type == "quit" then
-    running = false
-  else 
-    local path = inChan:pop(true)
-    local extra = inChan:pop(true)
-    local extra2 = inChan:pop(true)
-    local status, thing = load(type, path, extra, extra2)
-    outChan:push(type)
-    outChan:push(path)
-    outChan:push(status)
-    outChan:push(thing)
-  end
+    local type = inChan:pop(true)
+    if type == "quit" then
+        running = false
+    else 
+        local path = inChan:pop(true)
+        local extra = inChan:pop(true)
+        local extra2 = inChan:pop(true)
+        local status, thing = load(type, path, extra, extra2)
+        outChan:push(type)
+        outChan:push(path)
+        outChan:push(status)
+        outChan:push(thing)
+    end
 end
 print("Exiting loader thread.")

--- a/lua/lib/async-loader-thread.lua
+++ b/lua/lib/async-loader-thread.lua
@@ -40,5 +40,6 @@ while running do
         outChan:push(status)
         outChan:push(thing)
     end
+    collectgarbage("collect")
 end
 print("Exiting loader thread.")

--- a/lua/lib/async-loader-thread.lua
+++ b/lua/lib/async-loader-thread.lua
@@ -10,23 +10,16 @@ local outChan = lovr.thread.getChannel("AlloLoaderResponses")
 local inChan = lovr.thread.getChannel("AlloLoaderRequests")
 
 function load(type, path, extra, extra2)
-  if type == "model-asset" then
+  if type == "model" then
     -- expects a lovr blob in extra
     return pcall(lovr.data.newModelData, extra)
-  elseif type == "texture-asset" then
+  elseif type == "texture" or type == "image" then
     -- expects a lovr blob in extra
     -- expects a boolean 'flip' in extra2
     return pcall(lovr.data.newImage, extra, not extra2)
-  elseif type == "sound-asset" then
+  elseif type == "sound" then
     -- expects a lovr blob in extra
     return pcall(lovr.data.newSound, extra)
-  elseif type == "model" then
-    -- expects a file path in path
-    return pcall(lovr.data.newModelData, path)
-  elseif type == "base64png" then
-    local data = util.base64decode(extra)
-    local blob = lovr.data.newBlob(data, "texture")
-    return pcall(lovr.data.newImage, blob)
   else
     return false, "no such loader"
   end
@@ -42,6 +35,7 @@ while running do
     local extra = inChan:pop(true)
     local extra2 = inChan:pop(true)
     local status, thing = load(type, path, extra, extra2)
+    outChan:push(type)
     outChan:push(path)
     outChan:push(status)
     outChan:push(thing)

--- a/lua/lib/async-loader.lua
+++ b/lua/lib/async-loader.lua
@@ -15,8 +15,14 @@ local inChan = lovr.thread.getChannel("AlloLoaderResponses")
 function AsyncLoader:load(type, path, callback, extra, extra2)
   local key = type .. "-" .. path
   local req = self.requests[key]
-  assert(not req, "This is allready loading. Cache earlier: " .. key)
+  -- assert(not req, "This is allready loading. Cache earlier: " .. key)
 
+  if req then
+    callback = function (a)
+      req.callback(a)
+      callback(a)
+    end
+  end
   req = {callback= callback, type= type}
   self.requests[key] = req
   outChan:push(type)

--- a/lua/lib/async-loader.lua
+++ b/lua/lib/async-loader.lua
@@ -1,6 +1,6 @@
 -- Request = {callback: Callback}
 local AsyncLoader = {
-  requests = {}, -- {path: String -> req: Request}
+    requests = {}, -- {path: String -> req: Request}
 }
 
 local thread = lovr.thread.newThread("lib/async-loader-thread.lua")
@@ -13,37 +13,37 @@ local inChan = lovr.thread.getChannel("AlloLoaderResponses")
 -- Callback = callback(data: {ErrorString|data}, status: bool) -> Void
 -- AsyncLoader:load(type: Type, path: string, callback: Callback) -> Void
 function AsyncLoader:load(type, path, callback, extra, extra2)
-  local key = type .. "-" .. path
-  local req = self.requests[key]
-  if req then 
-    table.insert(req.callbacks, callback)
-    return
-  end
-  self.requests[key] = {callbacks = {callback}, type = type}
-  outChan:push(type)
-  outChan:push(path)
-  outChan:push(extra)
-  outChan:push(extra2)
+    local key = type .. "-" .. path
+    local req = self.requests[key]
+    if req then 
+        table.insert(req.callbacks, callback)
+        return
+    end
+    self.requests[key] = {callbacks = {callback}, type = type}
+    outChan:push(type)
+    outChan:push(path)
+    outChan:push(extra)
+    outChan:push(extra2)
 end
 
 function AsyncLoader:poll()
-  local type = inChan:pop()
-  local path = inChan:pop()
-  if path == nil then return end
-  local status = inChan:pop(true)
-  local dataOrError = inChan:pop(true)
-  local key = type .. "-" .. path
-  local req = self.requests[key]
-  self.requests[key] = nil
-  for i,callback in ipairs(req.callbacks) do
-    callback(dataOrError, status)
-  end
+    local type = inChan:pop()
+    local path = inChan:pop()
+    if path == nil then return end
+    local status = inChan:pop(true)
+    local dataOrError = inChan:pop(true)
+    local key = type .. "-" .. path
+    local req = self.requests[key]
+    self.requests[key] = nil
+    for i,callback in ipairs(req.callbacks) do
+        callback(dataOrError, status)
+    end
 end
 
 function AsyncLoader:shutdown()
-  print("Shutting down loader...")
-  outChan:push("quit")
-  thread:wait()
+    print("Shutting down loader...")
+    outChan:push("quit")
+    thread:wait()
 end
 
 return AsyncLoader

--- a/lua/lib/async-loader.lua
+++ b/lua/lib/async-loader.lua
@@ -21,14 +21,8 @@ function AsyncLoader:load(type, path, callback, extra, extra2)
   end
 
   local req = self.requests[path]
-  if req then
-    local oldCallback = req.callback
-    req.callback = function(modelData, status)
-      oldCallback(modelData, status)
-      callback(modelData, status)
-    end
-    return
-  end
+  assert(not req, "This is allready loading. Cache earlier: " .. type .. " - " .. path)
+
   req = {callback= callback, type= type}
   self.requests[path] = req
   outChan:push(type)

--- a/lua/main.lua
+++ b/lua/main.lua
@@ -1,19 +1,19 @@
 local path = lovr.filesystem.getRequirePath()
 local cpath = package.cpath
 cpath = cpath .. 
-	";?.so;?.dll;" ..
-  lovr.filesystem.getSource() .. "/../deps/allonet/?.so;" ..
-	lovr.filesystem.getSource() .. "/../build/deps/allonet/?.dylib;" ..
-	lovr.filesystem.getSource() .. "/../../build/deps/allonet/?.dylib;"
+    ";?.so;?.dll;" ..
+    lovr.filesystem.getSource() .. "/../deps/allonet/?.so;" ..
+    lovr.filesystem.getSource() .. "/../build/deps/allonet/?.dylib;" ..
+    lovr.filesystem.getSource() .. "/../../build/deps/allonet/?.dylib;"
 if lovr.filesystem.getExecutablePath() and lovr.system.getOS() == "Windows" then
-	cpath = cpath .. lovr.filesystem.getExecutablePath():gsub("lovr.exe", "?.dll")
+    cpath = cpath .. lovr.filesystem.getExecutablePath():gsub("lovr.exe", "?.dll")
 end
 path = path ..
-  ";lib/alloui/lua/?.lua" ..
-  ";lib/alloui/lib/cpml/?.lua" ..
-  ";lib/ent/lua/?.lua" ..
-  ";lib/ent/lua/?/init.lua" 
-	
+    ";lib/alloui/lua/?.lua" ..
+    ";lib/alloui/lib/cpml/?.lua" ..
+    ";lib/ent/lua/?.lua" ..
+    ";lib/ent/lua/?/init.lua" 
+
 
 lovr.filesystem.setRequirePath(path)
 package.cpath = cpath
@@ -25,7 +25,7 @@ allonet = util.load_allonet()
 local ffi = require 'ffi'
 
 ffi.cdef [[
-  void visor_media_init(void);
+    void visor_media_init(void);
 ]]
 ffi.C.visor_media_init()
 
@@ -37,38 +37,38 @@ namespace = require "engine.namespace"
 
 local ok, mouse = pcall(require, "lib.lovr-mouse")
 if not ok then
-  print("No mouse available", mouse)
-  mouse = nil
+    print("No mouse available", mouse)
+    mouse = nil
 end
 
 -- Load namespace basics
 do
-	-- This should be only used in helper threads. Make sure this matches thread/helper/boot.lua
-	local space = namespace.space("minimal")
-
-	-- PL classes missing? add here:
-	for _,v in ipairs{"class", "pretty", "stringx", "tablex"} do
-		space[v] = require("pl." .. v)
-	end
-	space.ugly = require "engine.ugly"
-
-	require "engine.types"
+    -- This should be only used in helper threads. Make sure this matches thread/helper/boot.lua
+    local space = namespace.space("minimal")
+    
+    -- PL classes missing? add here:
+    for _,v in ipairs{"class", "pretty", "stringx", "tablex"} do
+        space[v] = require("pl." .. v)
+    end
+    space.ugly = require "engine.ugly"
+    
+    require "engine.types"
 end
 do
-	local space = namespace.space("standard", "minimal")
-
-	space.cpml = require "cpml"
-	for _,v in ipairs{"bound2", "bound3", "vec2", "vec3", "quat", "mat4", "color", "utils"} do
-		space[v] = space.cpml[v]
-	end
-	require "engine.loc"
-
-	require "engine.ent"
-	space.ent.singleThread = singleThread
-	require "engine.common_ent"
-	require "engine.lovr"
-  require "engine.mode"
-  require "lib.util"
+    local space = namespace.space("standard", "minimal")
+    
+    space.cpml = require "cpml"
+    for _,v in ipairs{"bound2", "bound3", "vec2", "vec3", "quat", "mat4", "color", "utils"} do
+        space[v] = space.cpml[v]
+    end
+    require "engine.loc"
+    
+    require "engine.ent"
+    space.ent.singleThread = singleThread
+    require "engine.common_ent"
+    require "engine.lovr"
+    require "engine.mode"
+    require "lib.util"
 end
 
 namespace.prepare("alloverse", "standard", function(space)
@@ -85,339 +85,339 @@ local loadCo = nil
 local urlToHandle = nil
 local restoreData = nil
 function lovr.load(args)
-  print("lovr.load(", pretty.write(args), ")")
-  lovr.system.requestPermission('audiocapture')
-  if args.restart then
-    restoreData = json.decode(args.restart)
-    urlToHandle = restoreData.url
-  end
-  lovr.handlers["handleurl"] = function(url)
-    if ent.root then
-      print("Opening URL:", url)
-      ent.root:route("onHandleUrl", url)
-    else
-      print("Storing URL to open when UI is available:", url)
-      urlToHandle = url
+    print("lovr.load(", pretty.write(args), ")")
+    lovr.system.requestPermission('audiocapture')
+    if args.restart then
+        restoreData = json.decode(args.restart)
+        urlToHandle = restoreData.url
     end
-  end
-  loadCo = coroutine.create(_asyncLoad)
+    lovr.handlers["handleurl"] = function(url)
+        if ent.root then
+            print("Opening URL:", url)
+            ent.root:route("onHandleUrl", url)
+        else
+            print("Storing URL to open when UI is available:", url)
+            urlToHandle = url
+        end
+    end
+    loadCo = coroutine.create(_asyncLoad)
 end
 function _asyncLoad()
-  function check(threadname)
-    local deadline = lovr.timer.getTime() + 5
-    local chan = lovr.thread.getChannel(threadname)
-    while lovr.timer.getTime() < deadline do
-      local m = chan:peek()
-      if m == "booted" then
-        chan:pop()
-        return chan
-      end
-      coroutine.yield()
+    function check(threadname)
+        local deadline = lovr.timer.getTime() + 5
+        local chan = lovr.thread.getChannel(threadname)
+        while lovr.timer.getTime() < deadline do
+            local m = chan:peek()
+            if m == "booted" then
+                chan:pop()
+                return chan
+            end
+            coroutine.yield()
+        end
+        error(threadname.." didn't start in time")
     end
-    error(threadname.." didn't start in time")
-  end
-
-  storeThread = lovr.thread.newThread("lib/lovr-store-thread.lua")
-  storeThread:start()
-  Store.singleton():registerDefaults{
-    recentPlaces = {
-      {name="Alloverse Arcade", url="alloplace://arcade.places.alloverse.com"},
-      {name="Developer Sandbox", url="alloplace://sandbox.places.alloverse.com"},
-      {name="Nevyn's place", url="alloplace://nevyn.places.alloverse.com"}
-    },
-    debug= false,
-    avatarName= "female",
-    username= "",
-    micGain= 1.5
-  }
-  if lovr.audio then
-    local capDevs = lovr.audio.getDevices("capture")
-    local defaultCandidate = nil
-    for k, v in ipairs(capDevs) do 
-      v.id = nil 
-      if v.default or string.find(v.name, "default") or string.find(v.name, "Default") or defaultCandidate == nil then
-        defaultCandidate = v.name
-      end
+    
+    storeThread = lovr.thread.newThread("lib/lovr-store-thread.lua")
+    storeThread:start()
+    Store.singleton():registerDefaults{
+        recentPlaces = {
+            {name="Alloverse Arcade", url="alloplace://arcade.places.alloverse.com"},
+            {name="Developer Sandbox", url="alloplace://sandbox.places.alloverse.com"},
+            {name="Nevyn's place", url="alloplace://nevyn.places.alloverse.com"}
+        },
+        debug= false,
+        avatarName= "female",
+        username= "",
+        micGain= 1.5
+    }
+    if lovr.audio then
+        local capDevs = lovr.audio.getDevices("capture")
+        local defaultCandidate = nil
+        for k, v in ipairs(capDevs) do 
+            v.id = nil 
+            if v.default or string.find(v.name, "default") or string.find(v.name, "Default") or defaultCandidate == nil then
+                defaultCandidate = v.name
+            end
+        end
+        print("Available microphone/capture audio devices:", pretty.write(capDevs), "uuh", pretty.write(Store.singleton():load("currentMic")), "yeah")
+        Store.singleton():save("availableCaptureDevices", capDevs)
+        if Store.singleton():load("currentMic") == nil and defaultCandidate then
+            print("Setting default mic candidate", defaultCandidate)
+            Store.singleton():save("currentMic", {name= defaultCandidate, status="pending"}, true)
+        end
     end
-    print("Available microphone/capture audio devices:", pretty.write(capDevs), "uuh", pretty.write(Store.singleton():load("currentMic")), "yeah")
-    Store.singleton():save("availableCaptureDevices", capDevs)
-    if Store.singleton():load("currentMic") == nil and defaultCandidate then
-      print("Setting default mic candidate", defaultCandidate)
-      Store.singleton():save("currentMic", {name= defaultCandidate, status="pending"}, true)
-    end
-  end
-  
-	menuServerThread = lovr.thread.newThread("threads/menuserv_main.lua")
-  menuServerThread:start()
-  menuServerPort = check("menuserv"):pop(true)
-  menuAppsThread = lovr.thread.newThread("threads/menuapps_main.lua")
-  lovr.thread.getChannel("appserv"):push(menuServerPort)
-  lovr.thread.getChannel("appserv"):push(lovr.headset and lovr.headset.getName() or "desktop")
-  print("starting appserv...")
-  menuAppsThread:start()
-  check("appserv")
-  return "done"
+    
+    menuServerThread = lovr.thread.newThread("threads/menuserv_main.lua")
+    menuServerThread:start()
+    menuServerPort = check("menuserv"):pop(true)
+    menuAppsThread = lovr.thread.newThread("threads/menuapps_main.lua")
+    lovr.thread.getChannel("appserv"):push(menuServerPort)
+    lovr.thread.getChannel("appserv"):push(lovr.headset and lovr.headset.getName() or "desktop")
+    print("starting appserv...")
+    menuAppsThread:start()
+    check("appserv")
+    return "done"
 end
 function _asyncLoadResume()
-  local costatus, err = coroutine.resume(loadCo)
-  if err ~= "done" then
-    if costatus == false then
-      print("Booting failed with error", err)
-      error(err)
-    end
-    return
-  end
-  print("Pre-boot completed, launching UI")
-  
-  -- great, all the threads are started. Let's create some UI.
-  -- (We can't do this in the above coroutine because allonet stores
-  --  the coroutine you call set_*_callback on :S)
-  loadCo = nil
-	ent.root = require("scenes.scenemanager")(menuServerPort)
-	ent.root:route("onBoot") -- This will only be sent once
-  ent.root:insert()
-  
-  lovr.handlers["keypressed"] = function(code, scancode, repetition)
-    ent.root:route("onKeyPress", code, scancode, repetition)
-  end
-  lovr.handlers["keyreleased"] = function(code, scancode)
-    ent.root:route("onKeyReleased", code, scancode)
-  end
-  lovr.handlers["textinput"] = function(text, code)
-    ent.root:route("onTextInput", text, code)
-  end
-  lovr.handlers["mousemoved"] = function(x, y, dx, dy)
-    ent.root:route("onMouseMoved", x, y, dx, dy)
-  end
-  lovr.handlers["mousepressed"] = function(x, y, button)
-    ent.root:route("onMousePressed", x, y, button)
-    local inx =     x * flat.width  / flat.pixwidth  - flat.width/2    -- Convert pixel x,y to our coordinate system
-		local iny = - ( y * flat.height / flat.pixheight - flat.height/2 ) -- GLFW has flipped y-coord
-    ent.root:route("onPress", lovr.math.vec2(inx, iny)) -- ui2 compat
-  end
-  lovr.handlers["mousereleased"] = function(x, y, button)
-    ent.root:route("onMouseReleased", x, y, button)
-    local inx =     x * flat.width  / flat.pixwidth  - flat.width/2    -- Convert pixel x,y to our coordinate system
-		local iny = - ( y * flat.height / flat.pixheight - flat.height/2 ) -- GLFW has flipped y-coord
-    ent.root:route("onRelease", lovr.math.vec2(inx, iny)) -- ui2 compat
-  end
-  lovr.handlers["wheelmoved"] = function(horizontal, vertical)
-    ent.root:route("onMouseScrolled", horizontal, vertical)
-  end
-
-  lovr.handlers["filedrop"] = function(path)
-    ent.root:route("onFileDrop", path)
-  end
-
-
-  local cursors = {}
-  local currentCursorName = "arrow"
-  if mouse then
-    for _, name in ipairs({"arrow", "hand", "crosshair"}) do
-      cursors[name] = mouse.getSystemCursor(name)
-    end
-
-    lovr.mouse = {
-      position = lovr.math.newVec2(-1, -1),
-      buttons = { false, false },
-      setRelativeMode = function(enable)
-        if mouse then mouse.setRelativeMode(enable) end
-      end,
-      setCursor = function(newCursorName)
-        if mouse and newCursorName ~= currentCursorName then 
-          mouse.setCursor(cursors[newCursorName]) 
-          currentCursorName = newCursorName
+    local costatus, err = coroutine.resume(loadCo)
+    if err ~= "done" then
+        if costatus == false then
+            print("Booting failed with error", err)
+            error(err)
         end
-      end,
-      setHidden = function(hidden)
-        mouse.setHidden(hidden)
-      end
-    }
-  end
+        return
+    end
+    print("Pre-boot completed, launching UI")
+    
+    -- great, all the threads are started. Let's create some UI.
+    -- (We can't do this in the above coroutine because allonet stores
+    --  the coroutine you call set_*_callback on :S)
+    loadCo = nil
+    ent.root = require("scenes.scenemanager")(menuServerPort)
+    ent.root:route("onBoot") -- This will only be sent once
+    ent.root:insert()
+    
+    lovr.handlers["keypressed"] = function(code, scancode, repetition)
+        ent.root:route("onKeyPress", code, scancode, repetition)
+    end
+    lovr.handlers["keyreleased"] = function(code, scancode)
+        ent.root:route("onKeyReleased", code, scancode)
+    end
+    lovr.handlers["textinput"] = function(text, code)
+        ent.root:route("onTextInput", text, code)
+    end
+    lovr.handlers["mousemoved"] = function(x, y, dx, dy)
+        ent.root:route("onMouseMoved", x, y, dx, dy)
+    end
+    lovr.handlers["mousepressed"] = function(x, y, button)
+        ent.root:route("onMousePressed", x, y, button)
+        local inx =     x * flat.width  / flat.pixwidth  - flat.width/2    -- Convert pixel x,y to our coordinate system
+        local iny = - ( y * flat.height / flat.pixheight - flat.height/2 ) -- GLFW has flipped y-coord
+        ent.root:route("onPress", lovr.math.vec2(inx, iny)) -- ui2 compat
+    end
+    lovr.handlers["mousereleased"] = function(x, y, button)
+        ent.root:route("onMouseReleased", x, y, button)
+        local inx =     x * flat.width  / flat.pixwidth  - flat.width/2    -- Convert pixel x,y to our coordinate system
+        local iny = - ( y * flat.height / flat.pixheight - flat.height/2 ) -- GLFW has flipped y-coord
+        ent.root:route("onRelease", lovr.math.vec2(inx, iny)) -- ui2 compat
+    end
+    lovr.handlers["wheelmoved"] = function(horizontal, vertical)
+        ent.root:route("onMouseScrolled", horizontal, vertical)
+    end
+    
+    lovr.handlers["filedrop"] = function(path)
+        ent.root:route("onFileDrop", path)
+    end
+    
+    
+    local cursors = {}
+    local currentCursorName = "arrow"
+    if mouse then
+        for _, name in ipairs({"arrow", "hand", "crosshair"}) do
+            cursors[name] = mouse.getSystemCursor(name)
+        end
+        
+        lovr.mouse = {
+            position = lovr.math.newVec2(-1, -1),
+            buttons = { false, false },
+            setRelativeMode = function(enable)
+                if mouse then mouse.setRelativeMode(enable) end
+            end,
+            setCursor = function(newCursorName)
+                if mouse and newCursorName ~= currentCursorName then 
+                    mouse.setCursor(cursors[newCursorName]) 
+                    currentCursorName = newCursorName
+                end
+            end,
+            setHidden = function(hidden)
+                mouse.setHidden(hidden)
+            end
+        }
+    end
 end
 
 function lovr.onNetConnected(net, url, place_name)
-  if place_name == "Menu" then
-    if urlToHandle then
-      print("Opening stored URL:", urlToHandle)
-      ent.root:route("onHandleUrl", urlToHandle)
-      urlToHandle = nil
+    if place_name == "Menu" then
+        if urlToHandle then
+            print("Opening stored URL:", urlToHandle)
+            ent.root:route("onHandleUrl", urlToHandle)
+            urlToHandle = nil
+        end
+    else
+        if restoreData then
+            lovr.scenes.net.engines.pose.poseToRestore = restoreData.rootPose
+            lovr.scenes.net.engines.pose.yaw = restoreData.yaw
+            restoreData = nil
+        end
     end
-  else
-    if restoreData then
-      lovr.scenes.net.engines.pose.poseToRestore = restoreData.rootPose
-      lovr.scenes.net.engines.pose.yaw = restoreData.yaw
-      restoreData = nil
-    end
-  end
 end
 
 function lovr.restart()
-  local restoreData = {}
-  if lovr.scenes.net then
-    restoreData.url = lovr.scenes.net.url
-    restoreData.rootPose = {lovr.scenes.net:getAvatar().components.transform:getMatrix():unpack(true)}
-    restoreData.yaw = lovr.scenes.net.engines.pose.yaw
-  end
-  local urlToRestore = lovr.scenes.net and lovr.scenes.net.url
-  print("Restarting; disconnecting (restoring to", urlToRestore, ")...")
-  optchainm(lovr.scenes, "net.onDisconnect", 1000, "Disconnected from lovr.restart")
-  print("Shutting down threads...")
-  lovr.thread.getChannel("menuserv"):push("exit")
-  lovr.thread.getChannel("appserv"):push("exit")
-  menuServerThread:wait()
-  menuAppsThread:wait()
-  Store.singleton():shutdown()
-
-  loader:shutdown()
-  print("Done, restarting.")
-  if restoreData.url then
-    return json.encode(restoreData)
-  else
-    return nil
-  end
+    local restoreData = {}
+    if lovr.scenes.net then
+        restoreData.url = lovr.scenes.net.url
+        restoreData.rootPose = {lovr.scenes.net:getAvatar().components.transform:getMatrix():unpack(true)}
+        restoreData.yaw = lovr.scenes.net.engines.pose.yaw
+    end
+    local urlToRestore = lovr.scenes.net and lovr.scenes.net.url
+    print("Restarting; disconnecting (restoring to", urlToRestore, ")...")
+    optchainm(lovr.scenes, "net.onDisconnect", 1000, "Disconnected from lovr.restart")
+    print("Shutting down threads...")
+    lovr.thread.getChannel("menuserv"):push("exit")
+    lovr.thread.getChannel("appserv"):push("exit")
+    menuServerThread:wait()
+    menuAppsThread:wait()
+    Store.singleton():shutdown()
+    
+    loader:shutdown()
+    print("Done, restarting.")
+    if restoreData.url then
+        return json.encode(restoreData)
+    else
+        return nil
+    end
 end
 
 function _updateMouse()
-  if mouse == nil then return end
-
-  local px, py = lovr.mouse.position:unpack()
-  local x, y = mouse.getPosition()
-  lovr.mouse.position:set(x, y)
-  local oldButtons = tablex.copy(lovr.mouse.buttons)
-  lovr.mouse.buttons = {mouse.isDown(1), mouse.isDown(2)}
-  
-  if px ~= x or py ~= y then
-    lovr.event.push('mousemoved', x, y, x - px, y - py, false)
-  end
-  for i, pb in ipairs(oldButtons) do
-    local b = lovr.mouse.buttons[i]
-    if b and not pb then
-      lovr.event.push("mousepressed", x, y, i)
-    elseif not b and pb then
-      lovr.event.push("mousereleased", x, y, i)
+    if mouse == nil then return end
+    
+    local px, py = lovr.mouse.position:unpack()
+    local x, y = mouse.getPosition()
+    lovr.mouse.position:set(x, y)
+    local oldButtons = tablex.copy(lovr.mouse.buttons)
+    lovr.mouse.buttons = {mouse.isDown(1), mouse.isDown(2)}
+    
+    if px ~= x or py ~= y then
+        lovr.event.push('mousemoved', x, y, x - px, y - py, false)
     end
-  end
+    for i, pb in ipairs(oldButtons) do
+        local b = lovr.mouse.buttons[i]
+        if b and not pb then
+            lovr.event.push("mousepressed", x, y, i)
+        elseif not b and pb then
+            lovr.event.push("mousereleased", x, y, i)
+        end
+    end
 end
 
 function lovr.update(dt)
-  if loadCo then
-    _asyncLoadResume()
-  end
-  Store.singleton():poll()
-  if lovr.mouse then
-    _updateMouse()
-  end
-  loader:poll()
-  if ent.root then
-    ent.root:route("onUpdate", dt)
-    entity_cleanup()
-  end
-
-  calculateFramerateBasedOnActivity()
+    if loadCo then
+        _asyncLoadResume()
+    end
+    Store.singleton():poll()
+    if lovr.mouse then
+        _updateMouse()
+    end
+    loader:poll()
+    if ent.root then
+        ent.root:route("onUpdate", dt)
+        entity_cleanup()
+    end
+    
+    calculateFramerateBasedOnActivity()
 end
 
 function lovr.draw(isMirror)
-  lovr.graphics.origin()
-  drawMode()
-  if ent.root then
-    ent.root:route("onDraw", isMirror)
-  end
+    lovr.graphics.origin()
+    drawMode()
+    if ent.root then
+        ent.root:route("onDraw", isMirror)
+    end
 end
 
 local skippedFrames = 0
 local frameSkip = 0
 function lovr.mirror()
-  drawMode()
-  lovr.graphics.reset()
-  lovr.graphics.origin()
-  local pixwidth = lovr.graphics.getWidth()   -- Window pixel width and height
-  local pixheight = lovr.graphics.getHeight()
-  local aspect = pixwidth/pixheight
-  local proj = lovr.math.mat4():perspective(0.01, 100, 67*(3.14/180), aspect)
-  lovr.graphics.setProjection(1, proj)
-  lovr.graphics.setShader(nil)
-  lovr.graphics.setColor(1,1,1,1)
-  lovr.graphics.clear()
-  lovr.draw(true)
-
-  if ent.root then
-    ent.root:route("onMirror")
-  end
+    drawMode()
+    lovr.graphics.reset()
+    lovr.graphics.origin()
+    local pixwidth = lovr.graphics.getWidth()   -- Window pixel width and height
+    local pixheight = lovr.graphics.getHeight()
+    local aspect = pixwidth/pixheight
+    local proj = lovr.math.mat4():perspective(0.01, 100, 67*(3.14/180), aspect)
+    lovr.graphics.setProjection(1, proj)
+    lovr.graphics.setShader(nil)
+    lovr.graphics.setColor(1,1,1,1)
+    lovr.graphics.clear()
+    lovr.draw(true)
+    
+    if ent.root then
+        ent.root:route("onMirror")
+    end
 end
 
 local wasActive = false
 function calculateFramerateBasedOnActivity()
-  local isActive = lovr.isFocused
-  if lovr.headset then
-    isActive = isActive or lovr.headset.isTracked()
-  end
-  if wasActive ~= isActive then
-    wasActive = isActive
-    if util.isDesktop() then
-      -- glfwSwapInterval broken
-      frameSkip = isActive and 0 or 25
+    local isActive = lovr.isFocused
+    if lovr.headset then
+        isActive = isActive or lovr.headset.isTracked()
     end
-  end
+    if wasActive ~= isActive then
+        wasActive = isActive
+        if util.isDesktop() then
+            -- glfwSwapInterval broken
+            frameSkip = isActive and 0 or 25
+        end
+    end
 end
 
 lovr.isFocused = true
 function lovr.focus(focused)
-  lovr.isFocused = focused
-  if ent.root then
-    ent.root:route("onFocus", focused)
-  end
+    lovr.isFocused = focused
+    if ent.root then
+        ent.root:route("onFocus", focused)
+    end
 end
 
 local permissionsHaveRetried = false
 function lovr.permission(permission, granted)
-  print("Permission ", permission, "response", granted)
-  if permission == "audiocapture" and granted and lovr.scenes and lovr.scenes.net and not permissionsHaveRetried then
-    permissionsHaveRetried = true
-    print("Mic permissions have been granted, reopening mic.")
-    lovr.scenes.net.engines.sound:retryMic()
-  end
+    print("Permission ", permission, "response", granted)
+    if permission == "audiocapture" and granted and lovr.scenes and lovr.scenes.net and not permissionsHaveRetried then
+        permissionsHaveRetried = true
+        print("Mic permissions have been granted, reopening mic.")
+        lovr.scenes.net.engines.sound:retryMic()
+    end
 end
 
 function lovr.run()
-  lovr.timer.step()
-  if lovr.load then lovr.load(arg) end
-  return function()
-    lovr.event.pump()
-    for name, a, b, c, d in lovr.event.poll() do
-      if name == 'restart' then
-        local cookie = lovr.restart and lovr.restart()
-        return 'restart', cookie
-      elseif name == 'quit' and (not lovr.quit or not lovr.quit(a)) then
-        return a or 0
-      end
-      if lovr.handlers[name] then lovr.handlers[name](a, b, c, d) end
-    end
-    local dt = lovr.timer.step()
-    local beforeWork = lovr.timer.getTime()
-    if lovr.headset then
-      lovr.headset.update(dt)
-    end
-    if lovr.update then lovr.update(dt) end
-    if lovr.graphics then
-      lovr.graphics.origin()
-      if lovr.draw then
-        skippedFrames = skippedFrames + 1
-        if skippedFrames > frameSkip then
-          skippedFrames = 0
-          if lovr.headset and lovr.headset.isTracked() then
-            lovr.headset.renderTo(lovr.draw)
-          end
-          if lovr.graphics.hasWindow() then
-            lovr.mirror()
-          end
-          lovr.graphics.present()
+    lovr.timer.step()
+    if lovr.load then lovr.load(arg) end
+    return function()
+        lovr.event.pump()
+        for name, a, b, c, d in lovr.event.poll() do
+            if name == 'restart' then
+                local cookie = lovr.restart and lovr.restart()
+                return 'restart', cookie
+            elseif name == 'quit' and (not lovr.quit or not lovr.quit(a)) then
+                return a or 0
+            end
+            if lovr.handlers[name] then lovr.handlers[name](a, b, c, d) end
         end
-      end
+        local dt = lovr.timer.step()
+        
+        if lovr.headset then
+            lovr.headset.update(dt)
+        end
+        if lovr.update then lovr.update(dt) end
+        if lovr.graphics then
+            lovr.graphics.origin()
+            if lovr.draw then
+                skippedFrames = skippedFrames + 1
+                if skippedFrames > frameSkip then
+                    skippedFrames = 0
+                    if lovr.headset and lovr.headset.isTracked() then
+                        lovr.headset.renderTo(lovr.draw)
+                    end
+                    if lovr.graphics.hasWindow() then
+                        lovr.mirror()
+                    end
+                    lovr.graphics.present()
+                end
+            end
+        end
+        
+        if lovr.math then
+            lovr.math.drain()
+        end
     end
-
-    if lovr.math then
-      lovr.math.drain()
-    end
-  end
 end

--- a/lua/main.lua
+++ b/lua/main.lua
@@ -379,8 +379,6 @@ function lovr.permission(permission, granted)
   end
 end
 
-
-local lastFrameTime = 0.0
 function lovr.run()
   lovr.timer.step()
   if lovr.load then lovr.load(arg) end

--- a/lua/main.lua
+++ b/lua/main.lua
@@ -418,16 +418,6 @@ function lovr.run()
       end
     end
 
-    -- XXX HACK vsync doesn't work on mac, so cap framerate
-    local afterWork = lovr.timer.getTime()
-    local deltaFramLastFrame = beforeWork-lastFrameTime
-    local maxFramerate = 60.0
-    local sleepAmount = 1.0/maxFramerate - deltaFramLastFrame
-    if lovr.system.getOS() == "macOS" and sleepAmount > 0 then
-      lovr.timer.sleep(sleepAmount)
-    end
-    lastFrameTime = beforeWork
-
     if lovr.math then
       lovr.math.drain()
     end


### PR DESCRIPTION
## GraphicsEng
- List of objects to draw is now managed between frames
- Move out a lot of the loading code
- Inline geometry now converted to .OBJ assets and loaded the same way as any other model!
- Doesn't modify model materials anymore, and therefore no longer need to track materials separately. 
- Uses our shader to apply textures for inline geometry (same as swapping gltf textures).
- Video also applies texture through shader instead of tracking model material. Simplified handling.

## AssetsEng
- Handles all of the object loadings
- Uses Async Loader more
- Caches lovr objects instead of data

## Async-Loader
- Doesn't handle the caching anymore
- Doesn't take filenames anymore. Use Asset.File instead.

## StatsEng
- Added a graph!

## Main.lua
- 4 space indentation
- Fixed the frame limiter