### PR TITLE
Move text rendering into Graphics Eng

### DIFF
--- a/lua/alloapps/avatar_chooser.lua
+++ b/lua/alloapps/avatar_chooser.lua
@@ -188,7 +188,7 @@ function AvatarChooser:_createUI()
   }
 
   self.avatarNameTag = ui.Surface(ui.Bounds(0, 0, 0,   0.2, 0.066, 0):rotate(3.14, 0, 1, 0):move(0, 0.25, -0.18):rotate(3.14/8, 1, 0, 0))
-  self.avatarNameTag.texture = AvatarChooser.assets.nameTag
+  self.avatarNameTag.material.texture = AvatarChooser.assets.nameTag
   self.avatarNameTag.hasTransparency = true
   self.avatarNameTagLabel = ui.Label {
     bounds= ui.Bounds(0, 0, 0,   0.16, 0.062, 0.001),

--- a/lua/eng/graphics_eng.lua
+++ b/lua/eng/graphics_eng.lua
@@ -27,7 +27,7 @@ function GraphicsEng:_init()
     -- Paint every entity in a differnet shade? Nice to figure out what be longs what
     self.colorfulDebug = false
     -- Draw model boinding boxes?
-    self.drawAABBs = true
+    self.drawAABBs = false
     -- Draw spheres at the center of AABB's?
     self.drawAABBCenters = false
     

--- a/lua/eng/renderer.lua
+++ b/lua/eng/renderer.lua
@@ -343,7 +343,7 @@ function Renderer:prepareObjects(context)
                     min = lovr.math.newVec3( worldMin:unpack() ),
                     max =  lovr.math.newVec3( worldMax:unpack() ),
                     center = lovr.math.newVec3( worldCenter:unpack() ),
-                    radius = (worldMax - worldMin):length(),
+                    radius = (worldMax - worldMin):length() / 2,
                 }
             end
 
@@ -598,7 +598,9 @@ function Renderer:drawObject(object, context)
 
     context.stats.drawnObjects = context.stats.drawnObjects + 1
 
-    if self.debug == "distance" then
+    local applyColor = true
+    if self.debug and self.debug == "distance" then
+        applyColor = false
         lovr.graphics.setShader()
         local d = context.views[1].objectToCamera[object.id].distance/10
         lovr.graphics.setColor(d, d, d, 1)
@@ -611,7 +613,9 @@ function Renderer:drawObject(object, context)
 
     local material = object.material
     local color = material and material.color or {1,1,1,1}
-    lovr.graphics.setColor(table.unpack(color))
+    if applyColor then 
+        lovr.graphics.setColor(table.unpack(color))
+    end
 
     object.source:draw(object, context)
     lovr.graphics.pop()
@@ -621,6 +625,16 @@ function Renderer:drawObject(object, context)
         local w, h, d = (bb.max - bb.min):unpack()
         local x, y, z = bb.center:unpack()
         lovr.graphics.box("line", x, y, z, math.abs(w), math.abs(h), math.abs(d))
+        
+        -- local bb
+        
+        local bb = object.AABB.source
+        local w, h, d = (bb.max - bb.min):unpack()
+        local x, y, z = ((bb.min + bb.max)/2):unpack()
+        lovr.graphics.push()
+        lovr.graphics.transform(object.transform)
+        lovr.graphics.box("line", x,y,z, math.abs(w), math.abs(h), math.abs(d))
+        lovr.graphics.pop()
     end
 end
 
@@ -833,7 +847,6 @@ function Renderer:getFrustum(mat)
     local planes = {
         vec4(), vec4(), vec4(), vec4(), vec4(), vec4()
     }
-    -- local m11, m12, m13, m14, m21, m22, m23, m24, m31, m32, m33, m34, m41, m42, m43, m44 = mat:unpack(true)
     local m11, m21, m31, m41, m12, m22, m32, m42, m13, m23, m33, m43, m14, m24, m34, m44 = mat:unpack(true)
 
     -- Left clipping plane

--- a/lua/eng/renderer.lua
+++ b/lua/eng/renderer.lua
@@ -207,21 +207,11 @@ function Renderer:prepareView(context)
 
     -- Determine the modelView and projection matrices
     if not view.modelView then
-        local modelView = lovr.math.newMat4()
-        lovr.graphics.getViewPose(1, modelView, true)
-        view.modelView = modelView
-    else
-        -- lovr.graphics.setViewPose(1, view.modelView, true)
-        -- lovr.graphics.setViewPose(2, view.modelView, true)
+        view.modelView = lovr.graphics.getViewPose(1, lovr.math.newMat4(), true)
     end
 
     if not view.projection then
-        local projection = lovr.math.newMat4()
-        lovr.graphics.getProjection(1, projection)
-        view.projection = projection
-    else
-        -- lovr.graphics.setProjection(1, view.projection)
-        -- lovr.graphics.setProjection(2, view.projection)
+        view.projection = lovr.graphics.getProjection(1, lovr.math.newMat4())
     end
 
     
@@ -625,6 +615,12 @@ function Renderer:drawObject(object, context)
         local w, h, d = (bb.max - bb.min):unpack()
         local x, y, z = bb.center:unpack()
         lovr.graphics.box("line", x, y, z, math.abs(w), math.abs(h), math.abs(d))
+
+        -- aabb radius
+        -- lovr.graphics.setColor(1,1,1,0.3)
+        -- lovr.graphics.setDepthTest("lequal", false)
+        -- lovr.graphics.sphere(x,y,z, bb.radius)
+        -- lovr.graphics.setDepthTest("lequal", true)
         
         -- local bb
         
@@ -635,6 +631,7 @@ function Renderer:drawObject(object, context)
         lovr.graphics.transform(object.transform)
         lovr.graphics.box("line", x,y,z, math.abs(w), math.abs(h), math.abs(d))
         lovr.graphics.pop()
+
     end
 end
 
@@ -833,9 +830,11 @@ function Renderer:cullTest(renderObject, context)
     local AABB = renderObject.AABB
     local center, radius = AABB.center, AABB.radius
     local frustum = context.view.frustum
+    -- some is off with the frustum so we expand the radius a bit
+    radius = radius * 1.4
     for i = 1, 6 do
         local f = frustum[i]
-        local e = center:dot(vec3(f.x, f.y, f.z)) + f.w + radius
+        local e = f.x * center.x + f.y * center.y + f.z * center.z + f.w + radius
         if e < 0 then return true end -- if outside any plane
     end
     return false

--- a/lua/eng/renderer.lua
+++ b/lua/eng/renderer.lua
@@ -608,6 +608,11 @@ function Renderer:drawObject(object, context)
     end
 
     object.source:draw(object, context)
+
+    if context.drawTextBoxes and object.source.hasText then
+        local text = object.source.text
+        lovr.graphics.box("line", 0,0,0, text.boxSize.x, text.boxSize.y,0)
+    end
     lovr.graphics.pop()
     
     if context.drawAABB then

--- a/lua/eng/renderer.lua
+++ b/lua/eng/renderer.lua
@@ -320,6 +320,7 @@ function Renderer:prepareObjects(context)
             -- TODO: smarts based on changes in material
             if object.material then
                 renderObject.material = {}
+                renderObject.material.color = object.material.color or {1,1,1,1}
                 renderObject.material.roughness = object.material.roughness or 1
                 renderObject.material.metalness = object.material.metalness or 1
                 renderObject.material.diffuseTexture = object.material.diffuseTexture
@@ -594,7 +595,6 @@ function Renderer:drawObject(object, context)
         end
     end
 
-    lovr.graphics.setColor(1,1,1,1)
     context.stats.drawnObjects = context.stats.drawnObjects + 1
 
     if self.debug == "distance" then
@@ -607,6 +607,11 @@ function Renderer:drawObject(object, context)
 
     lovr.graphics.push()
     lovr.graphics.transform(object.transform)
+
+    local material = object.material
+    local color = material and material.color or {1,1,1,1}
+    lovr.graphics.setColor(table.unpack(color))
+
     object.source:draw(object, context)
     lovr.graphics.pop()
     

--- a/lua/eng/stats_eng.lua
+++ b/lua/eng/stats_eng.lua
@@ -156,18 +156,4 @@ function StatsEng:drawGraph()
     self.graphNames = {}
 end
 
-function StatsEng:onDraw2()
-    lovr.graphics.setShader(nil)
-    lovr.graphics.setColor(1,1,1,1)
-    lovr.graphics.setFont(flat.font)
-    lovr.graphics.sphere(0,0,-2)
-    lovr.graphics.print(
-        self:statsString(),
-        0,0,0, 
-        1, 
-        0,0,1,0,0
-        -- 'right','top'
-    )
-end
-
 return StatsEng

--- a/lua/eng/text_eng.lua
+++ b/lua/eng/text_eng.lua
@@ -48,7 +48,7 @@ function TextEng:onUpdate()
 end
 
 --- Draws all text components
-function TextEng:onDraw() 
+function TextEng:onDraw()
     lovr.graphics.setShader()
     self.font:setPixelDensity(32)
     lovr.graphics.setFont(self.font)
@@ -60,90 +60,6 @@ function TextEng:onDraw()
     end
     letters.draw()
     
-    lovr.graphics.pop()
-end
-
-function TextEng:drawText(eid, entity, text)
-    local object = self.parent.engines.graphics.renderObjects[eid]
-    local mat = object and object.lovr.material
-    if mat then
-        lovr.graphics.setColor(mat:getColor())
-    else
-        lovr.graphics.setColor(1,1,1,1)
-    end
-    lovr.graphics.push()
-    -- lovr.graphics.transform(entity.components.transform:getMatrix())
-    
-    -- sets a dynamic text scale that fits within a width, if such parameter has been set
-    local dynamicTextScale = 0
-    
-    if text.fitToWidth then
-        
-        -- backwards compatibility
-        if type(text.fitToWidth) == "number" then
-            text.width = text.fitToWidth
-            text.fitToWidth = true
-        end
-        
-        local textLabelWidth = lovr.graphics.getFont():getWidth(text.string)
-        dynamicTextScale = text.width / textLabelWidth  
-    else
-        -- Fit text size to the element's height instead
-        dynamicTextScale = text.height and text.height or 1.0
-    end
-    
-    -- old implementation:
-    -- local wrap = text.wrap and text.wrap / (text.height and text.height or 1) or 0
-    
-    local wrap = 0
-    -- only care about setting wrap is fitToWidth hasn't been set
-    if not text.fitToWidth then
-        if text.wrap then
-            -- backwards compatibility
-            if type(text.wrap) == "number" then
-                text.width = text.wrap
-                text.wrap = true
-            end
-            
-            wrap = text.width and text.width / (text.height and text.height or 1) or 0
-        end
-    end
-    
-    if text.halign == "left" then
-        lovr.graphics.translate(-text.width/2,0,0)
-    elseif text.halign == "right" then
-        lovr.graphics.translate(text.width/2,0,0)
-    end
-    
-    -- Make sure the text never overflows the height of the container (unless it's wrapped, which is fine.)
-    if dynamicTextScale > text.height then
-        dynamicTextScale = text.height
-    end
-    
-    
-    lovr.graphics.print(
-        text.string,
-        0, 0, 0.01,
-        dynamicTextScale, --text.height and text.height or 1.0, 
-        0, 0, 0, 0,
-        wrap,
-        text.halign and text.halign or "center",
-        text.valign and text.valign or "middle"
-    )
-
-    if text.insertionMarker then
-        lovr.graphics.setColor(0, 0, 0, math.sin(lovr.timer.getTime()*5)*0.5 + 0.6)
-        local actualLabelWidth, lines = lovr.graphics.getFont():getWidth(text.string, wrap)
-        actualLabelWidth = actualLabelWidth * dynamicTextScale
-        local lastLine = string.match(text.string, "[^%c]*$")
-        local lastLineWidth = lovr.graphics.getFont():getWidth(lastLine) * dynamicTextScale
-        local height = self.font:getHeight()*dynamicTextScale
-        lovr.graphics.line(
-        lastLineWidth + 0.01, height/2 - height*(lines-1), 0,
-        lastLineWidth + 0.01, height/2 - height*lines, 0
-    )
-    end
-
     lovr.graphics.pop()
 end
 

--- a/lua/eng/text_eng.lua
+++ b/lua/eng/text_eng.lua
@@ -67,7 +67,7 @@ end
 function TextEng:onFocusChanged(newEnt, focusType)
     if focusType == "key" then
         self.firstResponder = newEnt
-        if true or lovr.headset then
+        if lovr.headset then
             letters.displayKeyboard()
         end
     else

--- a/lua/eng/text_eng.lua
+++ b/lua/eng/text_eng.lua
@@ -78,7 +78,7 @@ function TextEng:drawText(eid, entity, text)
         lovr.graphics.setColor(1,1,1,1)
     end
     lovr.graphics.push()
-    lovr.graphics.transform(entity.components.transform:getMatrix())
+    -- lovr.graphics.transform(entity.components.transform:getMatrix())
     
     -- sets a dynamic text scale that fits within a width, if such parameter has been set
     local dynamicTextScale = 0

--- a/lua/eng/text_eng.lua
+++ b/lua/eng/text_eng.lua
@@ -48,16 +48,10 @@ function TextEng:onUpdate()
 end
 
 --- Draws all text components
-function TextEng:onDraw2() 
+function TextEng:onDraw() 
     lovr.graphics.setShader()
     self.font:setPixelDensity(32)
     lovr.graphics.setFont(self.font)
-    for eid, entity in pairs(self.client.state.entities) do
-        local text = entity.components.text
-        if text ~= nil then
-            self:drawText(eid, entity, text)
-        end
-    end
     
     lovr.graphics.push()
     lovr.graphics.transform(self.parent.inverseCameraTransform)
@@ -160,7 +154,7 @@ end
 function TextEng:onFocusChanged(newEnt, focusType)
     if focusType == "key" then
         self.firstResponder = newEnt
-        if lovr.headset then
+        if true or lovr.headset then
             letters.displayKeyboard()
         end
     else

--- a/lua/eng/text_eng.lua
+++ b/lua/eng/text_eng.lua
@@ -48,7 +48,7 @@ function TextEng:onUpdate()
 end
 
 --- Draws all text components
-function TextEng:onDraw() 
+function TextEng:onDraw2() 
     lovr.graphics.setShader()
     self.font:setPixelDensity(32)
     lovr.graphics.setFont(self.font)

--- a/lua/eng/text_eng.lua
+++ b/lua/eng/text_eng.lua
@@ -50,9 +50,6 @@ end
 --- Draws all text components
 function TextEng:onDraw()
     lovr.graphics.setShader()
-    self.font:setPixelDensity(32)
-    lovr.graphics.setFont(self.font)
-    
     lovr.graphics.push()
     lovr.graphics.transform(self.parent.inverseCameraTransform)
     if not lovr.headset then

--- a/lua/lib/alloavatar.lua
+++ b/lua/lib/alloavatar.lua
@@ -197,7 +197,7 @@ function AlloBodyPart:nameTagSpec()
             {
                 text = {
                     string = self.displayName,
-                    height = 0.66,
+                    height = 0.062,
                     halign = "center",
                     width = 0.16,
                     fitToWidth = true


### PR DESCRIPTION
## Moves all the text rendering into graphics_eng 
... and the renderer pipe getting text frustum culled. ♦️ 

Finally managed to move all the text calculations into the build step as well so we just do that once per change 💥 (and correct boxes)

Pushes some fixes to lovr as well so that's bumped to latest dev. 22 commits merged (almost) cleanly 🎸 
- a cmake thing, the d8->dx change, had some extra params from bjorn

## Also improves bounding box and culling a whole lot

Boxes are now rotated properly. This lead to increased computation so to combat that I also compare transforms to see if new AABBs need to be calculated for next frame.
This is more correct, and certainly looks prettier when drawing the boxes, but not critically useful as we still only cull on the radius.. 

## Eeeh
Text is not scaled 100% as before. It's better in come places (the caret in input boxes) but weird in some (placesettings stats). 